### PR TITLE
Add .zip file support for inclusion of cover letters.

### DIFF
--- a/src/app/api/profile/resume/route.ts
+++ b/src/app/api/profile/resume/route.ts
@@ -119,7 +119,10 @@ export const GET = async (req: NextRequest, res: NextApiResponse) => {
     } else if (fileType === ".doc" || fileType === ".docx") {
       contentType =
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-    } else {
+    } else if (fileType === ".zip") {
+      contentType = "application/x-zip-compressed";
+    }  
+     else {
       return NextResponse.json(
         { error: "Unsupported file type" },
         { status: 400 }

--- a/src/components/profile/CreateResume.tsx
+++ b/src/components/profile/CreateResume.tsx
@@ -158,7 +158,7 @@ function CreateResume({
                     <FormControl>
                       <Input
                         type="file"
-                        accept=".pdf,.doc,.docx"
+                        accept=".pdf,.doc,.docx,.zip"
                         onChange={(e) => {
                           field.onChange(e.target.files?.[0] || null);
                         }}

--- a/src/models/createResumeForm.schema.ts
+++ b/src/models/createResumeForm.schema.ts
@@ -5,6 +5,7 @@ const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
 const SUPPORTED_MIME_TYPES = [
   "application/pdf", // PDF
   "application/msword", // Word .doc
+  "application/x-zip-compressed", // Windows .zip
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // Word .docx
 ];
 


### PR DESCRIPTION
In regards to issue  #11 I have added zip file support. This change has been implemented as a work around for uploading cover letter to server until a GUI option can be added and inside the database of course.  Works fine on Windows 11. Had trouble adding 7zip file support to make it more accessible

Hoping in future to add documentation via a static site (blogging) generator later. Was thinking next js.