### PR TITLE
Docker image and compose now operational on Ubuntu 22.04 Desktop AMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,9 @@ ENV NEXTAUTH_URL: http://localhost:3000
 ENV AUTH_TRUST_HOST: http://localhost:3000
 ENV OLLAMA_BASE_URL=http://host.docker.internal:11434
 ENV OPENAI_API_KEY=sk-xxx
-RUN addgroup --system --gid 1001 nodejs && \
-    adduser --system --uid 1001 nextjs
+# Add user to group nodejs as the non-root user nextjs
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser --system --uid 1001 --ingroup nodejs nextjs
 
 # Set the correct permission for prerender cache
 RUN mkdir .next


### PR DESCRIPTION
Hi again @Gsync,

Sorry closed previous PR and made new one as previous one got too messy.

# Intro
I have been able to implement a fix and run the app in Ubuntu 22.04 with Docker compose up. If this PR gets merged, we can then ask users for the Linux distros if they are still getting the installation issues before closing issues 8 and 10. 

This PR Fixes the following error upon using docker compose up command. `unable to open database file: /data/dev.db`

As Docker aggressively caches layers, users may need to run docker compose build --no-cache app if issues continue.

# Summary of changes
- Tested on Ubuntu 22.04 (cleared Docker cache to re‐build runner stage).
- Added the non-root user nextjs to the nodejs system group in the Dockerfile with the --ingroup parameter which should fix the issue in Linux. Haven't tested in Windows yet, but confident this should not be an issue.