### PR TITLE
Fix Ollama base URL handling and fetch URLs

### DIFF
--- a/src/components/settings/AiSettings.tsx
+++ b/src/components/settings/AiSettings.tsx
@@ -1,4 +1,5 @@
 "use client";
+const OLLAMA = process.env.NEXT_PUBLIC_OLLAMA_BASE_URL || "http://localhost:11434";
 import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import {
@@ -118,7 +119,7 @@ function AiSettings() {
     setIsLoadingModels(true);
     setFetchError("");
     try {
-      const response = await fetch("http://localhost:11434/api/tags");
+      const response = await fetch(`${OLLAMA}/api/tags`);
       if (!response.ok) {
         if (selectedModel.provider === AiProvider.OLLAMA) {
           setFetchError(
@@ -148,7 +149,7 @@ function AiSettings() {
   const keepModelAlive = async (modelName: string) => {
     try {
       // Send a request to keep the model loaded for 1 hour
-      await fetch("http://localhost:11434/api/generate", {
+      await fetch(`${OLLAMA}/api/generate`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -169,7 +170,7 @@ function AiSettings() {
     setRunningModelError("");
     setRunningModelName("");
     try {
-      const response = await fetch("http://localhost:11434/api/ps");
+      const response = await fetch('${OLLAMA}/api/ps');
       if (!response.ok) {
         if (selectedModel.provider === AiProvider.OLLAMA) {
           setRunningModelError(

--- a/src/utils/ai.utils.ts
+++ b/src/utils/ai.utils.ts
@@ -1,3 +1,7 @@
+const OLLAMA =
+  process.env.OLLAMA_BASE_URL ||
+  process.env.NEXT_PUBLIC_OLLAMA_BASE_URL ||
+  "http://localhost:11434";
 import { JobResponse } from "@/models/job.model";
 import { AiProvider } from "@/models/ai.model";
 
@@ -35,7 +39,7 @@ export const checkIfModelIsRunning = async (
 
   try {
     // Check if Ollama service is accessible
-    const response = await fetch("http://localhost:11434/api/ps", {
+    const response = await fetch(`${OLLAMA}/api/ps`, {
       signal: AbortSignal.timeout(5000), // 5 second timeout
     });
 
@@ -86,7 +90,7 @@ export const fetchRunningModels = async (): Promise<{
   error?: string;
 }> => {
   try {
-    const response = await fetch("http://localhost:11434/api/ps", {
+    const response = await fetch(`${OLLAMA}/api/ps`, {
       signal: AbortSignal.timeout(5000),
     });
 


### PR DESCRIPTION
Created an ENV variable NEXT_PUBLIC_OLLAMA_BASE_URL to handle Ollama hosted in another server than localhost. Defaults to localhost when no value is provided.