### PR TITLE
feat: add openai-compatible provider for custom OpenAI API endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ NEXTAUTH_URL=http://localhost:3737
 
 OPENAI_API_KEY=your-openai-api-key-here
 
+# OpenAI-compatible provider (e.g. LM Studio, Ollama with OpenAI API, LiteLLM)
+OPENAI_COMPAT_BASE_URL=http://127.0.0.1:8000
+OPENAI_COMPAT_API_KEY=your-openai-compatible-api-key-here
+
 # DeepSeek API Key - get from https://platform.deepseek.com
 DEEPSEEK_API_KEY=your-deepseek-api-key-here
 

--- a/src/actions/apiKey.actions.ts
+++ b/src/actions/apiKey.actions.ts
@@ -186,3 +186,44 @@ export async function getOllamaBaseUrl(userId?: string): Promise<string> {
   }
   return process.env.OLLAMA_BASE_URL || "http://127.0.0.1:11434";
 }
+
+async function resolveApiKeyRecord(
+  userId: string,
+  provider: string,
+): Promise<{ value: string; encrypted: boolean } | null> {
+  const apiKey = await db.apiKey.findUnique({
+    where: {
+      userId_provider: { userId, provider },
+    },
+  });
+  if (!apiKey) return null;
+  if (apiKey.iv === "") return { value: apiKey.encryptedKey, encrypted: false };
+  const { decrypt } = await import("@/lib/encryption");
+  return { value: decrypt(apiKey.encryptedKey, apiKey.iv), encrypted: true };
+}
+
+export async function getOpenaiCompatibleBaseUrl(userId?: string): Promise<string> {
+  try {
+    const resolvedUserId = userId ?? (await getCurrentUser())?.id;
+    if (resolvedUserId) {
+      const record = await resolveApiKeyRecord(resolvedUserId, "openai-compatible");
+      if (record) return record.value;
+    }
+  } catch {
+    // Fall through to defaults
+  }
+  return process.env.OPENAI_COMPAT_BASE_URL || "http://127.0.0.1:8000";
+}
+
+export async function getOpenaiCompatibleApiKey(userId?: string): Promise<string | null> {
+  try {
+    const resolvedUserId = userId ?? (await getCurrentUser())?.id;
+    if (resolvedUserId) {
+      const record = await resolveApiKeyRecord(resolvedUserId, "openai-compatible-key");
+      if (record) return record.value;
+    }
+  } catch {
+    // Fall through to defaults
+  }
+  return process.env.OPENAI_COMPAT_API_KEY || null;
+}

--- a/src/app/api/ai/openai-compatible/models/route.ts
+++ b/src/app/api/ai/openai-compatible/models/route.ts
@@ -1,0 +1,43 @@
+import { auth } from "@/auth";
+import { NextResponse } from "next/server";
+import { resolveApiKey } from "@/lib/api-key-resolver";
+
+export async function GET() {
+  try {
+    const session = await auth();
+    const userId = session?.user?.id;
+
+    const baseURL = await resolveApiKey(userId, "openai-compatible");
+    if (!baseURL) {
+      return NextResponse.json(
+        { error: "OpenAI-compatible base URL not configured" },
+        { status: 500 },
+      );
+    }
+
+    const apiKey = await resolveApiKey(userId, "openai-compatible-key");
+    const headers: Record<string, string> = {};
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+
+    const cleanUrl = baseURL.replace(/\/+$/, "");
+    const response = await fetch(`${cleanUrl}/v1/models`, { headers });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Failed to fetch models: ${response.status}` },
+        { status: response.status },
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error fetching OpenAI-compatible models:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch models from OpenAI-compatible endpoint" },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/settings/api-keys/verify/route.ts
+++ b/src/app/api/settings/api-keys/verify/route.ts
@@ -8,7 +8,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ success: false, error: "Not authenticated" }, { status: 401 });
   }
 
-  const { provider, key } = await req.json();
+  const body = await req.json();
+  const { provider, key, apiKey } = body;
 
   if (!provider || !key) {
     return NextResponse.json(
@@ -26,7 +27,10 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const result = await verifier(key);
+    const verifyKey = provider === "openai-compatible"
+      ? { baseURL: key, apiKey }
+      : key;
+    const result = await verifier(verifyKey);
     return NextResponse.json(result);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Verification failed";

--- a/src/components/settings/ApiKeySettings.tsx
+++ b/src/components/settings/ApiKeySettings.tsx
@@ -77,6 +77,7 @@ function ApiKeySettings() {
     null,
   );
   const [inputValue, setInputValue] = useState("");
+  const [openaiCompatApiKey, setOpenaiCompatApiKey] = useState("");
   const [verifying, setVerifying] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [ollamaConnected, setOllamaConnected] = useState<boolean | null>(null);
@@ -122,10 +123,14 @@ function ApiKeySettings() {
 
     setVerifying(true);
     try {
+      const verifyBody =
+        provider === "openai-compatible"
+          ? { provider, key: inputValue, apiKey: openaiCompatApiKey || undefined }
+          : { provider, key: inputValue };
       const verifyRes = await fetch("/api/settings/api-keys/verify", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider, key: inputValue }),
+        body: JSON.stringify(verifyBody),
       });
       const verifyData = await verifyRes.json();
 
@@ -139,12 +144,22 @@ function ApiKeySettings() {
       }
 
       const providerConfig = PROVIDERS.find((p) => p.id === provider);
-      const saveResult = await saveApiKey({
+      const saveBaseUrlResult = await saveApiKey({
         provider,
         key: inputValue,
         sensitive: providerConfig?.sensitive ?? true,
       });
-      if (saveResult.success) {
+
+      let saveApiKeyResult: { success: boolean; message?: string } | null = null;
+      if (provider === "openai-compatible" && openaiCompatApiKey.trim()) {
+        saveApiKeyResult = await saveApiKey({
+          provider: "openai-compatible-key",
+          key: openaiCompatApiKey,
+          sensitive: true,
+        });
+      }
+
+      if (saveBaseUrlResult.success && (!saveApiKeyResult?.message || saveApiKeyResult.success)) {
         toast({
           variant: "success",
           title: "API key saved",
@@ -152,12 +167,13 @@ function ApiKeySettings() {
         });
         setEditingProvider(null);
         setInputValue("");
+        setOpenaiCompatApiKey("");
         await fetchKeys();
       } else {
         toast({
           variant: "destructive",
           title: "Save failed",
-          description: saveResult.message || "Failed to save API key",
+          description: (saveBaseUrlResult.message || saveApiKeyResult?.message || "Failed to save API key"),
         });
       }
     } catch (error) {
@@ -175,8 +191,12 @@ function ApiKeySettings() {
   const handleDelete = async (provider: ApiKeyProvider) => {
     setDeleting(provider);
     try {
-      const result = await deleteApiKey(provider);
-      if (result.success) {
+      const results = await Promise.all([
+        deleteApiKey(provider),
+        ...(provider === "openai-compatible" ? [deleteApiKey("openai-compatible-key" as ApiKeyProvider)] : []),
+      ]);
+      const allSuccess = results.every((r) => r.success);
+      if (allSuccess) {
         toast({
           variant: "success",
           title: "API key deleted",
@@ -187,7 +207,7 @@ function ApiKeySettings() {
         toast({
           variant: "destructive",
           title: "Error",
-          description: result.message || "Failed to delete API key",
+          description: "Failed to delete API key",
         });
       }
     } catch (error) {
@@ -200,6 +220,7 @@ function ApiKeySettings() {
   const handleCancel = () => {
     setEditingProvider(null);
     setInputValue("");
+    setOpenaiCompatApiKey("");
   };
 
   if (isLoading) {
@@ -250,19 +271,31 @@ function ApiKeySettings() {
                       )}
                     </CardDescription>
                   </div>
-                  {existingKey ? (
-                    <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 hover:bg-green-100 dark:hover:bg-green-900">
-                      <CheckCircle className="h-3 w-3 mr-1" />
-                      {provider.sensitive
-                        ? `····${existingKey.last4}`
-                        : existingKey.displayValue || existingKey.last4}
-                    </Badge>
-                  ) : (
-                    <Badge variant="secondary">Not configured</Badge>
-                  )}
-                </div>
-              </CardHeader>
-              {provider.id === "ollama" && (
+                    {existingKey ? (
+                      <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 hover:bg-green-100 dark:hover:bg-green-900">
+                       <CheckCircle className="h-3 w-3 mr-1" />
+                       {provider.sensitive
+                         ? `····${existingKey.last4}`
+                         : existingKey.displayValue || existingKey.last4}
+                     </Badge>
+                   ) : (
+                     <Badge variant="secondary">Not configured</Badge>
+                   )}
+                   {provider.id === "openai-compatible" && (
+                     <div className="ml-2">
+                       {keys.find((k) => k.provider === "openai-compatible-key") ? (
+                         <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                           <CheckCircle className="h-3 w-3 mr-1" />
+                           API Key
+                         </Badge>
+                       ) : (
+                         <Badge variant="outline">No API Key</Badge>
+                       )}
+                     </div>
+                   )}
+                 </div>
+               </CardHeader>
+                {provider.id === "ollama" && (
                 <div className="px-6 pb-3">
                   <div className="flex items-center gap-2">
                     {ollamaChecking ? (
@@ -313,6 +346,21 @@ function ApiKeySettings() {
                         className="mt-1"
                       />
                     </div>
+                    {provider.id === "openai-compatible" && (
+                      <div>
+                        <Label htmlFor={`key-${provider.id}-api`}>
+                          API Key (optional)
+                        </Label>
+                        <Input
+                          id={`key-${provider.id}-api`}
+                          type="password"
+                          placeholder="sk-..."
+                          value={openaiCompatApiKey}
+                          onChange={(e) => setOpenaiCompatApiKey(e.target.value)}
+                          className="mt-1"
+                        />
+                      </div>
+                    )}
                     <div className="flex gap-2">
                       <Button
                         size="sm"

--- a/src/lib/ai/provider-registry.server.ts
+++ b/src/lib/ai/provider-registry.server.ts
@@ -11,6 +11,9 @@ export const PROVIDER_FACTORIES: Record<
   (credential: string, modelName: string) => any
 > = {
   openai: (apiKey, model) => createOpenAI({ apiKey })(model),
+  "openai-compatible": () => {
+    throw new Error("openai-compatible is handled specially in getModel()");
+  },
   openrouter: (apiKey, model) =>
     createOpenAI({ apiKey, baseURL: "https://openrouter.ai/api/v1" })(model),
   deepseek: (apiKey, model) => createDeepSeek({ apiKey })(model),
@@ -21,7 +24,7 @@ export const PROVIDER_FACTORIES: Record<
 
 export const PROVIDER_VERIFIERS: Record<
   string,
-  (key: string) => Promise<{ success: boolean; error?: string }>
+  (key: any) => Promise<{ success: boolean; error?: string }>
 > = {
   openai: async (key) => {
     const res = await fetch("https://api.openai.com/v1/models", {
@@ -34,6 +37,25 @@ export const PROVIDER_VERIFIERS: Record<
           res.status === 401
             ? "Invalid API key"
             : `OpenAI returned ${res.status}`,
+      };
+    return { success: true };
+  },
+
+  "openai-compatible": async (key) => {
+    const params = typeof key === "object" ? key : { baseURL: key, apiKey: undefined };
+    const headers: Record<string, string> = {};
+    if (params.apiKey) {
+      headers["Authorization"] = `Bearer ${params.apiKey}`;
+    }
+    const baseUrl = params.baseURL.replace(/\/+$/, "");
+    const res = await fetch(`${baseUrl}/v1/models`, { headers });
+    if (!res.ok)
+      return {
+        success: false,
+        error:
+          res.status === 401
+            ? "Invalid API key"
+            : `OpenAI-compatible endpoint returned ${res.status}`,
       };
     return { success: true };
   },

--- a/src/lib/ai/provider-registry.ts
+++ b/src/lib/ai/provider-registry.ts
@@ -61,6 +61,26 @@ export const PROVIDER_REGISTRY: Record<string, ProviderRegistryEntry> = {
     },
   },
 
+  "openai-compatible": {
+    id: "openai-compatible",
+    displayName: "OpenAI Compatible",
+    credentialType: "base-url",
+    category: "local",
+    envVar: "OPENAI_COMPAT_BASE_URL",
+    defaultCredential: "http://127.0.0.1:8000",
+    modelsEndpoint: "openai-compatible/models",
+    parseModelsResponse: (data) =>
+      data.data?.map((m: any) => m.id) ?? [],
+    requiresRunningCheck: false,
+    supportsKeepAlive: false,
+    keyConfig: {
+      placeholder: "http://127.0.0.1:8000",
+      inputType: "text",
+      description: "Base URL for any OpenAI-compatible API (e.g. LM Studio, Ollama with OpenAI API, Azure OpenAI)",
+      sensitive: false,
+    },
+  },
+
   deepseek: {
     id: "deepseek",
     displayName: "DeepSeek",
@@ -117,7 +137,7 @@ export const PROVIDER_REGISTRY: Record<string, ProviderRegistryEntry> = {
   },
 };
 
-export const AI_PROVIDERS = ["ollama", "openai", "deepseek", "openrouter", "gemini"] as const;
+export const AI_PROVIDERS = ["ollama", "openai", "openai-compatible", "deepseek", "openrouter", "gemini"] as const;
 export type AiProviderId = (typeof AI_PROVIDERS)[number];
 
 export function getAiProviders(): ProviderRegistryEntry[] {

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -1,8 +1,9 @@
 import { resolveApiKey } from "@/lib/api-key-resolver";
 import { PROVIDER_REGISTRY } from "@/lib/ai/provider-registry";
 import { PROVIDER_FACTORIES } from "@/lib/ai/provider-registry.server";
+import { createOpenAI } from "@ai-sdk/openai";
 
-export type ProviderType = "openai" | "ollama" | "deepseek" | "openrouter" | "gemini";
+export type ProviderType = "openai" | "openai-compatible" | "ollama" | "deepseek" | "openrouter" | "gemini";
 
 export async function getModel(
   provider: ProviderType,
@@ -18,6 +19,11 @@ export async function getModel(
   const credential = await resolveApiKey(userId, provider);
   if (!credential)
     throw new Error(`${entry.displayName} credential not configured`);
+
+  if (provider === "openai-compatible") {
+    const apiKey = await resolveApiKey(userId, "openai-compatible-key");
+    return createOpenAI({ baseURL: credential, apiKey: apiKey || "" })(modelName);
+  }
 
   return factory(credential, modelName);
 }

--- a/src/lib/api-key-resolver.ts
+++ b/src/lib/api-key-resolver.ts
@@ -7,6 +7,7 @@ import { PROVIDER_REGISTRY } from "@/lib/ai/provider-registry";
 // RapidAPI is not in the AI provider registry but still needs env var resolution
 const EXTRA_ENV_VARS: Record<string, string> = {
   rapidapi: "RAPIDAPI_KEY",
+  "openai-compatible-key": "OPENAI_COMPAT_API_KEY",
 };
 
 export async function resolveApiKey(

--- a/src/lib/scraper/runner.ts
+++ b/src/lib/scraper/runner.ts
@@ -59,6 +59,8 @@ function getDefaultModelForProvider(provider: AiProvider): string {
       return OllamaModel.LLAMA3_2;
     case AiProvider.OPENAI:
       return OpenaiModel.GPT4O_MINI;
+    case AiProvider.OPENAI_COMPATIBLE:
+      return "";
     case AiProvider.DEEPSEEK:
       return DeepseekModel.DEEPSEEK_CHAT;
     case AiProvider.GEMINI:

--- a/src/models/ai.model.ts
+++ b/src/models/ai.model.ts
@@ -17,6 +17,7 @@ export interface AiModel {
 export enum AiProvider {
   OLLAMA = "ollama",
   OPENAI = "openai",
+  OPENAI_COMPATIBLE = "openai-compatible",
   DEEPSEEK = "deepseek",
   GEMINI = "gemini",
   OPENROUTER = "openrouter",

--- a/src/models/apiKey.model.ts
+++ b/src/models/apiKey.model.ts
@@ -1,4 +1,4 @@
-export type ApiKeyProvider = "openai" | "deepseek" | "openrouter" | "ollama" | "rapidapi";
+export type ApiKeyProvider = "openai" | "openai-compatible" | "openai-compatible-key" | "deepseek" | "openrouter" | "ollama" | "rapidapi";
 
 export interface ApiKeyRecord {
   id: string;

--- a/src/models/apiKey.schema.ts
+++ b/src/models/apiKey.schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const apiKeySaveSchema = z.object({
-  provider: z.enum(["openai", "deepseek", "openrouter", "ollama", "gemini", "rapidapi"]),
+  provider: z.enum(["openai", "openai-compatible", "openai-compatible-key", "deepseek", "openrouter", "ollama", "gemini", "rapidapi"]),
   key: z.string().min(1, "API key is required"),
   label: z.string().optional(),
   sensitive: z.boolean().default(true),


### PR DESCRIPTION
Disclosure: coding done by Qwen3.6-27B running locally to my machines.  

This adds support for any openai compatible api such as LM Studio, Llama.cpp, DwarfStar/DS4, VLLM, LiteLLM, Azure OpenAI (not tested but *should* work), etc.

I've reviewed the changes myself and they look reasonable and pretty isolated to just the places that make sense but I'm not sure if there's anything that isn't in line with the project's style guidelines or anything.

Commit message from Qwen: 

Add support for any OpenAI-compatible LLM API (e.g. LM Studio, Ollama with OpenAI API, LiteLLM, Azure OpenAI). Users configure a base URL and optional API key via the settings UI, or via OPENAI_COMPAT_BASE_URL and OPENAI_COMPAT_API_KEY env vars.

- Added OPENAI_COMPATIBLE to AiProvider enum
- Added registry entry with base-url credential type
- Added dual-credential resolution (base URL + optional API key)
- Added models API route and verifier
- Added second input in settings UI for API key
- Added helper functions for credential resolution