### PR TITLE
feat(cover-letter): add optional File attachment in data layer

### DIFF
--- a/__tests__/coverLetter.actions.spec.ts
+++ b/__tests__/coverLetter.actions.spec.ts
@@ -15,6 +15,7 @@ vi.mock("@prisma/client", () => {
     coverLetter: {
       findMany: vi.fn(),
       findFirst: vi.fn(),
+      findUnique: vi.fn(),
       count: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
@@ -23,6 +24,11 @@ vi.mock("@prisma/client", () => {
     profile: {
       findFirst: vi.fn(),
       create: vi.fn(),
+    },
+    file: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      delete: vi.fn(),
     },
     job: {
       findUnique: vi.fn(),
@@ -35,6 +41,10 @@ vi.mock("@prisma/client", () => {
 
 vi.mock("@/utils/user.utils", () => ({
   getCurrentUser: vi.fn(),
+}));
+
+vi.mock("@/actions/profile.actions", () => ({
+  deleteFile: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("coverLetterActions", () => {
@@ -79,8 +89,17 @@ describe("coverLetterActions", () => {
           profileId: true,
           title: true,
           content: true,
+          FileId: true,
           createdAt: true,
           updatedAt: true,
+          File: {
+            select: {
+              id: true,
+              fileName: true,
+              filePath: true,
+              fileType: true,
+            },
+          },
           _count: {
             select: { Job: true },
           },
@@ -166,6 +185,7 @@ describe("coverLetterActions", () => {
           title: "My Cover Letter",
           content:
             "This is the content of my cover letter for the position.",
+          FileId: null,
         },
       });
     });
@@ -176,25 +196,68 @@ describe("coverLetterActions", () => {
       (prisma.profile.findFirst as any).mockResolvedValue(null);
       (prisma.profile.create as any).mockResolvedValue({
         id: "new-profile-id",
+        coverLetters: [{ id: "cl-new" }],
       });
 
       const result = await createCoverLetter("New CL", "Content for the new cover letter here.");
 
       expect(result).toEqual({
         success: true,
-        data: { id: "new-profile-id" },
+        data: { id: "new-profile-id", coverLetters: [{ id: "cl-new" }] },
       });
       expect(prisma.profile.create).toHaveBeenCalledWith({
         data: {
           userId: mockUser.id,
           coverLetters: {
             create: [
-              { title: "New CL", content: "Content for the new cover letter here." },
+              {
+                title: "New CL",
+                content: "Content for the new cover letter here.",
+                FileId: null,
+              },
             ],
           },
         },
+        include: { coverLetters: { select: { id: true } } },
       });
       expect(prisma.coverLetter.create).not.toHaveBeenCalled();
+    });
+
+    it("should create a cover letter with an uploaded file", async () => {
+      (getCurrentUser as any).mockResolvedValue(mockUser);
+      (prisma.coverLetter.findFirst as any).mockResolvedValue(null);
+      (prisma.profile.findFirst as any).mockResolvedValue({
+        id: "profile-id",
+      });
+      (prisma.file.create as any).mockResolvedValue({ id: "file-1" });
+      (prisma.coverLetter.create as any).mockResolvedValue({
+        ...mockCoverLetter,
+        FileId: "file-1",
+      });
+
+      const result = await createCoverLetter(
+        "PDF Letter",
+        "",
+        "letter.pdf",
+        "data/files/cover-letters/letter.pdf",
+      );
+
+      expect(result?.success).toBe(true);
+      expect(prisma.file.create).toHaveBeenCalledWith({
+        data: {
+          fileName: "letter.pdf",
+          filePath: "data/files/cover-letters/letter.pdf",
+          fileType: "cover-letter",
+        },
+      });
+      expect(prisma.coverLetter.create).toHaveBeenCalledWith({
+        data: {
+          profileId: "profile-id",
+          title: "PDF Letter",
+          content: "",
+          FileId: "file-1",
+        },
+      });
     });
 
     it("should return error when title already exists", async () => {
@@ -316,6 +379,9 @@ describe("coverLetterActions", () => {
   describe("deleteCoverLetterById", () => {
     it("should delete a cover letter successfully", async () => {
       (getCurrentUser as any).mockResolvedValue(mockUser);
+      (prisma.coverLetter.findUnique as any).mockResolvedValue({
+        FileId: null,
+      });
       (prisma.coverLetter.delete as any).mockResolvedValue(
         mockCoverLetter,
       );
@@ -326,6 +392,20 @@ describe("coverLetterActions", () => {
       expect(prisma.coverLetter.delete).toHaveBeenCalledWith({
         where: { id: "cl-id", profile: { userId: "user-id" } },
       });
+    });
+
+    it("should delete attached file before deleting cover letter", async () => {
+      const { deleteFile } = await import("@/actions/profile.actions");
+      (getCurrentUser as any).mockResolvedValue(mockUser);
+      (prisma.coverLetter.findUnique as any).mockResolvedValue({
+        FileId: "file-1",
+      });
+      (prisma.coverLetter.delete as any).mockResolvedValue(mockCoverLetter);
+
+      const result = await deleteCoverLetterById("cl-id");
+
+      expect(result).toEqual({ success: true });
+      expect(deleteFile).toHaveBeenCalledWith("file-1");
     });
 
     it("should return error when user is not authenticated", async () => {
@@ -341,6 +421,9 @@ describe("coverLetterActions", () => {
 
     it("should handle database errors", async () => {
       (getCurrentUser as any).mockResolvedValue(mockUser);
+      (prisma.coverLetter.findUnique as any).mockResolvedValue({
+        FileId: null,
+      });
       (prisma.coverLetter.delete as any).mockRejectedValue(
         new Error("Database error"),
       );

--- a/prisma/migrations/20260803114428_cover_letter_file_upload/migration.sql
+++ b/prisma/migrations/20260803114428_cover_letter_file_upload/migration.sql
@@ -1,0 +1,20 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_CoverLetter" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "profileId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL DEFAULT '',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "FileId" TEXT,
+    CONSTRAINT "CoverLetter_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "Profile" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "CoverLetter_FileId_fkey" FOREIGN KEY ("FileId") REFERENCES "File" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_CoverLetter" ("content", "createdAt", "id", "profileId", "title", "updatedAt") SELECT "content", "createdAt", "id", "profileId", "title", "updatedAt" FROM "CoverLetter";
+DROP TABLE "CoverLetter";
+ALTER TABLE "new_CoverLetter" RENAME TO "CoverLetter";
+CREATE UNIQUE INDEX "CoverLetter_FileId_key" ON "CoverLetter"("FileId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,20 +95,23 @@ model CoverLetter {
   id        String   @id @default(uuid())
   profileId String
   title     String
-  content   String
+  content   String   @default("")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   profile   Profile  @relation(fields: [profileId], references: [id])
+  File      File?    @relation(fields: [FileId], references: [id])
+  FileId    String?  @unique
   Job       Job[]
 }
 
 model File {
-  id         String   @id @default(uuid())
-  fileName   String
-  filePath   String
-  fileType   String
-  uploadedAt DateTime @default(now())
-  Resume     Resume?
+  id          String       @id @default(uuid())
+  fileName    String
+  filePath    String
+  fileType    String
+  uploadedAt  DateTime     @default(now())
+  Resume      Resume?
+  CoverLetter CoverLetter?
 }
 
 model ResumeSection {

--- a/src/actions/coverLetter.actions.ts
+++ b/src/actions/coverLetter.actions.ts
@@ -5,6 +5,7 @@ import { handleError } from "@/lib/utils";
 import { getCurrentUser } from "@/utils/user.utils";
 import { APP_CONSTANTS } from "@/lib/constants";
 import { buildCoverLetterTitle } from "@/lib/coverLetterTitle";
+import { deleteFile } from "@/actions/profile.actions";
 
 // html:false escapes raw HTML in the model output before it is ever stored,
 // so the saved document is the same shape a hand-written letter produces.
@@ -12,9 +13,23 @@ const md = new MarkdownIt({ html: false, linkify: false, breaks: true });
 
 const MIN_CONTENT_LENGTH = 10;
 
+const createCoverLetterFileEntry = async (
+  fileName: string,
+  filePath: string,
+) => {
+  const entry = await prisma.file.create({
+    data: {
+      fileName,
+      filePath,
+      fileType: "cover-letter",
+    },
+  });
+  return entry.id;
+};
+
 export const getCoverLetterList = async (
   page: number = 1,
-  limit: number = APP_CONSTANTS.RECORDS_PER_PAGE
+  limit: number = APP_CONSTANTS.RECORDS_PER_PAGE,
 ): Promise<any | undefined> => {
   try {
     const user = await getCurrentUser();
@@ -37,8 +52,17 @@ export const getCoverLetterList = async (
           profileId: true,
           title: true,
           content: true,
+          FileId: true,
           createdAt: true,
           updatedAt: true,
+          File: {
+            select: {
+              id: true,
+              fileName: true,
+              filePath: true,
+              fileType: true,
+            },
+          },
           _count: {
             select: {
               Job: true,
@@ -66,7 +90,9 @@ export const getCoverLetterList = async (
 
 export const createCoverLetter = async (
   title: string,
-  content: string
+  content: string,
+  fileName?: string | null,
+  filePath?: string,
 ): Promise<any | undefined> => {
   try {
     const user = await getCurrentUser();
@@ -94,21 +120,35 @@ export const createCoverLetter = async (
       },
     });
 
+    const fileId =
+      fileName && filePath
+        ? await createCoverLetterFileEntry(fileName, filePath)
+        : null;
+    const normalizedContent = content?.trim() ? content : "";
+
     const res = profile?.id
       ? await prisma.coverLetter.create({
           data: {
             profileId: profile.id,
             title,
-            content,
+            content: normalizedContent,
+            FileId: fileId,
           },
         })
       : await prisma.profile.create({
           data: {
             userId: user.id,
             coverLetters: {
-              create: [{ title, content }],
+              create: [
+                {
+                  title,
+                  content: normalizedContent,
+                  FileId: fileId,
+                },
+              ],
             },
           },
+          include: { coverLetters: { select: { id: true } } },
         });
 
     return { success: true, data: res };
@@ -121,7 +161,10 @@ export const createCoverLetter = async (
 export const updateCoverLetter = async (
   id: string,
   title: string,
-  content: string
+  content: string,
+  fileId?: string,
+  fileName?: string,
+  filePath?: string,
 ): Promise<any | undefined> => {
   try {
     const user = await getCurrentUser();
@@ -129,9 +172,31 @@ export const updateCoverLetter = async (
       throw new Error("Not authenticated");
     }
 
+    let resolvedFileId = fileId;
+
+    if (!fileId && fileName && filePath) {
+      resolvedFileId = await createCoverLetterFileEntry(fileName, filePath);
+    }
+
+    const data: {
+      title: string;
+      content: string;
+      FileId?: string | null;
+    } = {
+      title,
+      content: content?.trim() ? content : "",
+    };
+
+    // Only touch FileId when a new file was uploaded or an existing id is kept.
+    if (fileName && filePath) {
+      data.FileId = resolvedFileId || null;
+    } else if (fileId !== undefined) {
+      data.FileId = resolvedFileId || null;
+    }
+
     const res = await prisma.coverLetter.update({
       where: { id, profile: { userId: user.id } },
-      data: { title, content },
+      data,
     });
 
     return { success: true, data: res };
@@ -142,12 +207,25 @@ export const updateCoverLetter = async (
 };
 
 export const deleteCoverLetterById = async (
-  coverLetterId: string
+  coverLetterId: string,
 ): Promise<any | undefined> => {
   try {
     const user = await getCurrentUser();
     if (!user) {
       throw new Error("Not authenticated");
+    }
+
+    const coverLetter = await prisma.coverLetter.findUnique({
+      where: { id: coverLetterId, profile: { userId: user.id } },
+      select: { FileId: true },
+    });
+
+    if (!coverLetter) {
+      throw new Error("Cover letter not found or access denied");
+    }
+
+    if (coverLetter.FileId) {
+      await deleteFile(coverLetter.FileId);
     }
 
     await prisma.coverLetter.delete({
@@ -163,7 +241,7 @@ export const deleteCoverLetterById = async (
 
 export const generateCoverLetterForJob = async (
   jobId: string,
-  markdown: string
+  markdown: string,
 ): Promise<any | undefined> => {
   try {
     const user = await getCurrentUser();
@@ -200,7 +278,7 @@ export const generateCoverLetterForJob = async (
     const title = buildCoverLetterTitle(
       job.JobTitle?.label ?? "Cover Letter",
       job.Company?.label ?? "",
-      existing.map((letter) => letter.title)
+      existing.map((letter) => letter.title),
     );
 
     const content = md.render(markdown);

--- a/src/actions/profile.actions.ts
+++ b/src/actions/profile.actions.ts
@@ -425,12 +425,13 @@ export const createResumeProfile = async (
 const createFileEntry = async (
   fileName: string | undefined,
   filePath: string | undefined,
+  fileType: string = "resume",
 ) => {
   const newFileEntry = await prisma.file.create({
     data: {
       fileName: fileName!,
       filePath: filePath!,
-      fileType: "resume",
+      fileType,
     },
   });
   return newFileEntry.id;
@@ -743,7 +744,10 @@ export const deleteFile = async (fileId: string) => {
   const file = await prisma.file.findFirst({
     where: {
       id: fileId,
-      Resume: { profile: { userId: user.id } },
+      OR: [
+        { Resume: { profile: { userId: user.id } } },
+        { CoverLetter: { profile: { userId: user.id } } },
+      ],
     },
   });
 

--- a/src/models/profile.model.ts
+++ b/src/models/profile.model.ts
@@ -130,6 +130,8 @@ export interface CoverLetter {
   profileId?: string;
   title: string;
   content: string;
+  FileId?: string | null;
+  File?: File | null;
   createdAt?: Date;
   updatedAt?: Date;
   _count?: {


### PR DESCRIPTION
## Summary
Add optional file attachment support for cover letters at the data/action layer (same File model pattern as resumes). No UI yet.

## Changes
- CoverLetter.FileId + migration
- create/update/list/delete with file support
- deleteFile ownership includes cover letters
- Unit tests

## Related Issues
Related to cover letter PDF upload feature request

## Testing
- npx vitest run __tests__/coverLetter.actions.spec.ts