### PR TITLE
ROB-74: add durable job evaluation lifecycle

### DIFF
--- a/prisma/migrations/20260813180000_job_evaluations/migration.sql
+++ b/prisma/migrations/20260813180000_job_evaluations/migration.sql
@@ -1,0 +1,38 @@
+-- Durable, source-independent asynchronous evaluation lifecycle.
+CREATE TABLE "JobEvaluation" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "jobId" TEXT NOT NULL,
+    "resumeId" TEXT NOT NULL,
+    "evaluatorKey" TEXT NOT NULL,
+    "evaluatorVersion" TEXT NOT NULL,
+    "definitionHash" TEXT NOT NULL,
+    "inputHash" TEXT NOT NULL,
+    "jobHash" TEXT NOT NULL,
+    "resumeHash" TEXT NOT NULL,
+    "inputSnapshot" TEXT NOT NULL,
+    "isCurrent" BOOLEAN NOT NULL DEFAULT true,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "attemptCount" INTEGER NOT NULL DEFAULT 0,
+    "nextAttemptAt" DATETIME,
+    "leaseToken" TEXT,
+    "leaseExpiresAt" DATETIME,
+    "resultJson" TEXT,
+    "resultHash" TEXT,
+    "lastError" TEXT,
+    "evaluatedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "JobEvaluation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "JobEvaluation_jobId_fkey" FOREIGN KEY ("jobId") REFERENCES "Job" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "JobEvaluation_resumeId_fkey" FOREIGN KEY ("resumeId") REFERENCES "Resume" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "JobEvaluation_jobId_resumeId_evaluatorKey_evaluatorVersion_inputHash_key"
+  ON "JobEvaluation"("jobId", "resumeId", "evaluatorKey", "evaluatorVersion", "inputHash");
+CREATE INDEX "JobEvaluation_userId_isCurrent_evaluatorKey_evaluatorVersion_idx"
+  ON "JobEvaluation"("userId", "isCurrent", "evaluatorKey", "evaluatorVersion");
+CREATE INDEX "JobEvaluation_userId_status_nextAttemptAt_idx"
+  ON "JobEvaluation"("userId", "status", "nextAttemptAt");
+CREATE INDEX "JobEvaluation_status_leaseExpiresAt_idx" ON "JobEvaluation"("status", "leaseExpiresAt");
+CREATE INDEX "JobEvaluation_jobId_isCurrent_idx" ON "JobEvaluation"("jobId", "isCurrent");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
   Tag            Tag[]
   Question       Question[]
   McpAccessToken McpAccessToken[]
+  JobEvaluation  JobEvaluation[]
   ChatConversation ChatConversation?
   defaultResumeId String?
   defaultResume   Resume?          @relation("UserDefaultResume", fields: [defaultResumeId], references: [id], onDelete: SetNull)
@@ -86,6 +87,7 @@ model Resume {
   File           File?           @relation(fields: [FileId], references: [id])
   FileId         String?         @unique
   Job            Job[]
+  JobEvaluation  JobEvaluation[]
   Automation     Automation[]
   defaultForUser User[]          @relation("UserDefaultResume")
   reviewData     String?
@@ -312,6 +314,7 @@ model Job {
   CoverLetter   CoverLetter? @relation(fields: [coverLetterId], references: [id])
   coverLetterId String?
   Notes         Note[]
+  evaluations   JobEvaluation[]
   tags        Tag[]
 
   // Automation discovery fields
@@ -528,6 +531,42 @@ model McpAccessToken {
 
   @@unique([userId, name])
   @@index([userId])
+}
+
+model JobEvaluation {
+  id               String   @id @default(uuid())
+  userId           String
+  jobId            String
+  resumeId         String
+  evaluatorKey     String
+  evaluatorVersion String
+  definitionHash   String
+  inputHash        String
+  jobHash          String
+  resumeHash       String
+  inputSnapshot    String
+  isCurrent        Boolean  @default(true)
+  status           String   @default("pending")
+  attemptCount     Int      @default(0)
+  nextAttemptAt    DateTime?
+  leaseToken       String?
+  leaseExpiresAt   DateTime?
+  resultJson       String?
+  resultHash       String?
+  lastError        String?
+  evaluatedAt      DateTime?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  job    Job    @relation(fields: [jobId], references: [id], onDelete: Cascade)
+  resume Resume @relation(fields: [resumeId], references: [id], onDelete: Cascade)
+
+  @@unique([jobId, resumeId, evaluatorKey, evaluatorVersion, inputHash])
+  @@index([userId, isCurrent, evaluatorKey, evaluatorVersion])
+  @@index([userId, status, nextAttemptAt])
+  @@index([status, leaseExpiresAt])
+  @@index([jobId, isCurrent])
 }
 
 model ChatConversation {

--- a/src/actions/mcpToken.actions.ts
+++ b/src/actions/mcpToken.actions.ts
@@ -19,6 +19,7 @@ export interface PublicTokenMeta {
 export async function createMcpToken(input: {
   name: string;
   expiryDays: 30 | 90 | 365;
+  type?: "agent" | "evaluation-worker";
 }): Promise<
   | { success: true; token: string; record: PublicTokenMeta }
   | { success: false; message: string }
@@ -44,7 +45,9 @@ export async function createMcpToken(input: {
         name: input.name.trim(),
         tokenHash: hash,
         tokenPrefix: prefix,
-        scopes: JSON.stringify(["jobs:write", "questions:write", "resume:write"]),
+        scopes: JSON.stringify(input.type === "evaluation-worker"
+          ? ["evaluations:worker"]
+          : ["jobs:write", "questions:write", "resume:write"]),
         expiresAt,
       },
     });
@@ -105,9 +108,18 @@ function toPublicMeta(record: {
     id: record.id,
     name: record.name,
     tokenPrefix: record.tokenPrefix,
-    scopes: JSON.parse(record.scopes) as string[],
+    scopes: parseScopes(record.scopes),
     expiresAt: record.expiresAt,
     lastUsedAt: record.lastUsedAt,
     createdAt: record.createdAt,
   };
+}
+
+function parseScopes(scopes: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(scopes);
+    return Array.isArray(parsed) && parsed.every((scope) => typeof scope === "string") ? parsed : [];
+  } catch {
+    return [];
+  }
 }

--- a/src/app/api/job-evaluations/[id]/complete/route.ts
+++ b/src/app/api/job-evaluations/[id]/complete/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { completeEvaluation } from "@/lib/jobEvaluations/service";
+import { boundedJson, stringField, workerAuth } from "@/lib/jobEvaluations/http";
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await workerAuth(request);
+  if ("error" in auth) return auth.error;
+  const parsed = await boundedJson(request);
+  if ("error" in parsed) return parsed.error;
+  const body = parsed.value as Record<string, unknown>;
+  const leaseToken = stringField(body.leaseToken, 200);
+  const inputHash = stringField(body.inputHash, 128);
+  if (!leaseToken || !inputHash || !body.result || typeof body.result !== "object" || Array.isArray(body.result) || JSON.stringify(body.result).length > 96_000) return NextResponse.json({ error: "Invalid completion" }, { status: 400 });
+  const outcome = await completeEvaluation(auth.userId, (await params).id, leaseToken, inputHash, body.result as Record<string, unknown>);
+  return outcome === "completed" || outcome === "idempotent" ? NextResponse.json({ status: outcome }) : NextResponse.json({ error: "Stale or conflicting completion" }, { status: 409 });
+}

--- a/src/app/api/job-evaluations/[id]/fail/route.ts
+++ b/src/app/api/job-evaluations/[id]/fail/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { failEvaluation } from "@/lib/jobEvaluations/service";
+import { boundedJson, stringField, workerAuth } from "@/lib/jobEvaluations/http";
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await workerAuth(request);
+  if ("error" in auth) return auth.error;
+  const parsed = await boundedJson(request, 8_000);
+  if ("error" in parsed) return parsed.error;
+  const body = parsed.value as Record<string, unknown>;
+  const leaseToken = stringField(body.leaseToken, 200);
+  const inputHash = stringField(body.inputHash, 128);
+  const error = stringField(body.error, 2_000);
+  if (!leaseToken || !inputHash || !error) return NextResponse.json({ error: "Invalid failure" }, { status: 400 });
+  const outcome = await failEvaluation(auth.userId, (await params).id, leaseToken, inputHash, error);
+  return outcome === "retry" || outcome === "failed" || outcome === "idempotent" ? NextResponse.json({ status: outcome }) : NextResponse.json({ error: "Stale or conflicting failure" }, { status: 409 });
+}

--- a/src/app/api/job-evaluations/route.ts
+++ b/src/app/api/job-evaluations/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/db";
+import { materializeCurrentEvaluations, claimEvaluations, type Evaluator } from "@/lib/jobEvaluations/service";
+import { boundedJson, stringField, workerAuth } from "@/lib/jobEvaluations/http";
+
+function evaluatorFrom(value: unknown): Evaluator | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const body = value as Record<string, unknown>;
+  const evaluatorKey = stringField(body.evaluatorKey, 100);
+  const evaluatorVersion = stringField(body.evaluatorVersion, 100);
+  if (!evaluatorKey || !evaluatorVersion || body.evaluatorDefinition === undefined || JSON.stringify(body.evaluatorDefinition).length > 32_000) return null;
+  return { evaluatorKey, evaluatorVersion, evaluatorDefinition: body.evaluatorDefinition };
+}
+
+export async function POST(request: Request) {
+  const auth = await workerAuth(request);
+  if ("error" in auth) return auth.error;
+  const parsed = await boundedJson(request);
+  if ("error" in parsed) return parsed.error;
+  const body = parsed.value as Record<string, unknown>;
+  const evaluator = evaluatorFrom(body);
+  const batch = typeof body.batch === "number" ? body.batch : NaN;
+  const leaseSeconds = typeof body.leaseSeconds === "number" ? body.leaseSeconds : NaN;
+  if (!evaluator || !Number.isInteger(batch) || batch < 1 || batch > 10 || !Number.isInteger(leaseSeconds) || leaseSeconds < 15 || leaseSeconds > 3600) {
+    return NextResponse.json({ error: "Invalid claim request" }, { status: 400 });
+  }
+  const rows = await claimEvaluations(auth.userId, evaluator, batch, leaseSeconds * 1000);
+  return NextResponse.json({ evaluations: rows.map((row) => ({ id: row.id, inputHash: row.inputHash, leaseToken: row.leaseToken, leaseExpiresAt: row.leaseExpiresAt, input: JSON.parse(row.inputSnapshot) })) });
+}
+
+export async function GET(request: Request) {
+  const auth = await workerAuth(request);
+  if ("error" in auth) return auth.error;
+  const searchParams = new URL(request.url).searchParams;
+  const evaluatorKey = searchParams.get("evaluatorKey");
+  const evaluatorVersion = searchParams.get("evaluatorVersion");
+  const definition = searchParams.get("definition");
+  if (!evaluatorKey || !evaluatorVersion || !definition) return NextResponse.json({ error: "evaluatorKey, evaluatorVersion, and definition are required" }, { status: 400 });
+  let evaluatorDefinition: unknown;
+  try { evaluatorDefinition = JSON.parse(definition); } catch { return NextResponse.json({ error: "Invalid definition" }, { status: 400 }); }
+  await materializeCurrentEvaluations(auth.userId, { evaluatorKey, evaluatorVersion, evaluatorDefinition });
+  const jobId = new URL(request.url).searchParams.get("jobId");
+  const rows = await prisma.jobEvaluation.findMany({ where: { userId: auth.userId, evaluatorKey, evaluatorVersion, ...(jobId ? { jobId } : {}) }, orderBy: { createdAt: "desc" } });
+  return NextResponse.json({ evaluations: rows.filter((row) => row.isCurrent), history: rows.filter((row) => !row.isCurrent).map((row) => ({ id: row.id, jobId: row.jobId, status: row.status, evaluatedAt: row.evaluatedAt })) });
+}

--- a/src/components/settings/McpAccessSettings.tsx
+++ b/src/components/settings/McpAccessSettings.tsx
@@ -153,6 +153,7 @@ export default function McpAccessSettings() {
   const [expiryDays, setExpiryDays] = useState<30 | 90 | 365>(
     APP_CONSTANTS.MCP_TOKEN_EXPIRY_DEFAULT_DAYS as 30 | 90 | 365,
   );
+  const [tokenType, setTokenType] = useState<"agent" | "evaluation-worker">("agent");
 
   const [revealedToken, setRevealedToken] = useState<{ token: string; name: string } | null>(null);
 
@@ -173,7 +174,7 @@ export default function McpAccessSettings() {
   const handleGenerate = async () => {
     if (!tokenName.trim()) return;
     setGenerating(true);
-    const result = await createMcpToken({ name: tokenName.trim(), expiryDays });
+    const result = await createMcpToken({ name: tokenName.trim(), expiryDays, type: tokenType });
     setGenerating(false);
     if (!result.success) {
       toastError(result.message);
@@ -183,6 +184,7 @@ export default function McpAccessSettings() {
     setShowGenerateDialog(false);
     setTokenName("");
     setExpiryDays(APP_CONSTANTS.MCP_TOKEN_EXPIRY_DEFAULT_DAYS as 30 | 90 | 365);
+    setTokenType("agent");
     await fetchTokens();
   };
 
@@ -304,6 +306,16 @@ export default function McpAccessSettings() {
                 onChange={(e) => setTokenName(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && handleGenerate()}
               />
+            </div>
+            <div className="space-y-2">
+              <Label>Token type</Label>
+              <Select value={tokenType} onValueChange={(value) => setTokenType(value as "agent" | "evaluation-worker")}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="agent">Agent (jobs, questions, resume)</SelectItem>
+                  <SelectItem value="evaluation-worker">Evaluation worker (evaluations only)</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
             <div className="space-y-2">
               <Label>Expires in</Label>

--- a/src/lib/ai/tools/preprocessing.ts
+++ b/src/lib/ai/tools/preprocessing.ts
@@ -236,7 +236,13 @@ export const convertResumeToText = (resume: Resume): Promise<string> => {
               return `## ${section.sectionTitle.toUpperCase()}\n${lines.join("\n")}`;
             }
             default:
-              return "";
+              {
+                const others = section.others
+                  ?.map((other) => removeHtmlTags(other.content))
+                  .filter(Boolean)
+                  .join("\n\n");
+                return others ? `## ${section.sectionTitle.toUpperCase()}\n${others}` : "";
+              }
           }
         })
         .filter(Boolean)

--- a/src/lib/jobEvaluations/http.ts
+++ b/src/lib/jobEvaluations/http.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { resolveMcpToken } from "@/lib/mcp/auth";
+
+export const MAX_BODY_BYTES = 128 * 1024;
+
+export async function workerAuth(request: Request) {
+  const auth = await resolveMcpToken(request);
+  if (!auth.ok) return { error: NextResponse.json({ error: auth.error }, { status: auth.status }) };
+  if (!auth.scopes.includes("evaluations:worker")) return { error: NextResponse.json({ error: "Missing evaluations:worker scope" }, { status: 403 }) };
+  return { userId: auth.userId };
+}
+
+export async function boundedJson(request: Request, maximum = MAX_BODY_BYTES): Promise<{ value: unknown } | { error: NextResponse }> {
+  const length = request.headers.get("content-length");
+  if (length && (!/^\d+$/.test(length) || Number(length) > maximum)) {
+    return { error: NextResponse.json({ error: "Payload too large" }, { status: 413 }) };
+  }
+  const reader = request.body?.getReader();
+  if (!reader) return { error: NextResponse.json({ error: "Expected JSON body" }, { status: 400 }) };
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > maximum) return { error: NextResponse.json({ error: "Payload too large" }, { status: 413 }) };
+    chunks.push(value);
+  }
+  try {
+    return { value: JSON.parse(new TextDecoder().decode(Buffer.concat(chunks))) };
+  } catch {
+    return { error: NextResponse.json({ error: "Malformed JSON" }, { status: 400 }) };
+  }
+}
+
+export function stringField(value: unknown, max: number): string | null {
+  return typeof value === "string" && value.length > 0 && value.length <= max ? value : null;
+}

--- a/src/lib/jobEvaluations/service.test.ts
+++ b/src/lib/jobEvaluations/service.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { isSubstantialDescription, sha256, stableJson, withSqliteBusyRetry } from "./service";
+
+describe("job evaluation identity helpers", () => {
+  it("uses recursively stable JSON hashes without changing array order", () => {
+    expect(stableJson({ b: { d: 1, c: 2 }, a: ["second", "first"] }))
+      .toBe('{"a":["second","first"],"b":{"c":2,"d":1}}');
+    expect(sha256({ b: 2, a: 1 })).toBe(sha256({ a: 1, b: 2 }));
+  });
+
+  it("uses the persisted normalized description rather than write-time metadata", () => {
+    expect(isSubstantialDescription(`<p>${Array.from({ length: 150 }, (_, i) => `word${i}`).join(" ")}</p>`)).toBe(true);
+    expect(isSubstantialDescription("short description")).toBe(false);
+  });
+
+  it("retries transient SQLite busy errors", async () => {
+    const operation = vi.fn()
+      .mockRejectedValueOnce(new Error("SQLITE_BUSY: database is locked"))
+      .mockResolvedValueOnce("claimed");
+    await expect(withSqliteBusyRetry(operation)).resolves.toBe("claimed");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-transient errors", async () => {
+    const operation = vi.fn().mockRejectedValue(new Error("validation failed"));
+    await expect(withSqliteBusyRetry(operation)).rejects.toThrow("validation failed");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/jobEvaluations/service.ts
+++ b/src/lib/jobEvaluations/service.ts
@@ -1,0 +1,148 @@
+import { createHash, randomUUID } from "crypto";
+import type { PrismaClient } from "@prisma/client";
+import prisma from "@/lib/db";
+import { preprocessResume } from "@/lib/ai/tools/preprocessing";
+import { removeHtmlTags, normalizeWhitespace } from "@/lib/ai/tools/text-processing";
+import { resumeDetailInclude } from "@/lib/jobs/resumeDetailInclude";
+
+export const FULL_DESCRIPTION_WORDS = 150;
+export const MAX_ATTEMPTS = 5;
+const RETRY_DELAYS_MS = [60_000, 5 * 60_000, 30 * 60_000, 2 * 60 * 60_000];
+
+export type Evaluator = { evaluatorKey: string; evaluatorVersion: string; evaluatorDefinition: unknown };
+
+export function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${stableJson(object[key])}`).join(",")}}`;
+}
+
+export function sha256(value: unknown): string {
+  return createHash("sha256").update(typeof value === "string" ? value : stableJson(value)).digest("hex");
+}
+
+export function isSubstantialDescription(description: string): boolean {
+  return normalizeWhitespace(removeHtmlTags(description)).split(/\s+/).filter(Boolean).length >= FULL_DESCRIPTION_WORDS;
+}
+
+export async function withSqliteBusyRetry<T>(operation: () => Promise<T>, attempts = 3): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      const code = (error as { code?: string }).code;
+      const message = error instanceof Error ? error.message : String(error);
+      if (attempt === attempts - 1 || (code !== "P2034" && !/SQLITE_BUSY/i.test(message))) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 10 * (attempt + 1)));
+    }
+  }
+  throw lastError;
+}
+
+async function canonicalInput(job: any, resume: any, evaluator: Evaluator) {
+  const preprocessed = await preprocessResume(resume);
+  if (!preprocessed.success) return null;
+  const description = normalizeWhitespace(removeHtmlTags(job.description));
+  if (!isSubstantialDescription(description)) return null;
+  const jobInput = {
+    title: job.JobTitle.label,
+    company: job.Company.label,
+    location: job.Location?.label ?? "",
+    workplaceType: job.workplaceType ?? "",
+    jobType: job.jobType,
+    salaryRange: job.salaryRange ?? "",
+    description,
+  };
+  const resumeInput = { id: resume.id, content: preprocessed.data.normalizedText };
+  const definition = evaluator.evaluatorDefinition;
+  const snapshot = { evaluator: { key: evaluator.evaluatorKey, version: evaluator.evaluatorVersion, definition }, job: jobInput, resume: resumeInput };
+  return {
+    jobHash: sha256(jobInput),
+    resumeHash: sha256(resumeInput),
+    definitionHash: sha256(definition),
+    inputHash: sha256(snapshot),
+    inputSnapshot: stableJson(snapshot),
+  };
+}
+
+export async function materializeCurrentEvaluations(userId: string, evaluator: Evaluator, db: PrismaClient = prisma) {
+  const user = await db.user.findUnique({ where: { id: userId }, select: { defaultResumeId: true } });
+  if (!user?.defaultResumeId) return [];
+  const resume = await db.resume.findFirst({ where: { id: user.defaultResumeId, profile: { userId } }, include: resumeDetailInclude });
+  if (!resume) return [];
+  const jobs = await db.job.findMany({
+    where: { userId },
+    include: { JobTitle: true, Company: true, Location: true },
+  });
+  const rows: any[] = [];
+  for (const job of jobs) {
+    const identity = await canonicalInput(job, resume, evaluator);
+    if (!identity) continue;
+    await db.jobEvaluation.updateMany({
+      where: { userId, jobId: job.id, evaluatorKey: evaluator.evaluatorKey, evaluatorVersion: evaluator.evaluatorVersion, isCurrent: true, inputHash: { not: identity.inputHash } },
+      data: { isCurrent: false },
+    });
+    let row = await db.jobEvaluation.findFirst({ where: { jobId: job.id, resumeId: resume.id, evaluatorKey: evaluator.evaluatorKey, evaluatorVersion: evaluator.evaluatorVersion, inputHash: identity.inputHash } });
+    if (!row) {
+      try {
+        row = await db.jobEvaluation.create({ data: { userId, jobId: job.id, resumeId: resume.id, evaluatorKey: evaluator.evaluatorKey, evaluatorVersion: evaluator.evaluatorVersion, isCurrent: true, status: "pending", ...identity } });
+      } catch (error: any) {
+        if (error?.code !== "P2002") throw error;
+        row = await db.jobEvaluation.findFirstOrThrow({ where: { jobId: job.id, resumeId: resume.id, evaluatorKey: evaluator.evaluatorKey, evaluatorVersion: evaluator.evaluatorVersion, inputHash: identity.inputHash } });
+      }
+    } else if (!row.isCurrent) {
+      row = await db.jobEvaluation.update({ where: { id: row.id }, data: { isCurrent: true } });
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+export async function claimEvaluations(userId: string, evaluator: Evaluator, batch: number, leaseMs: number, db: PrismaClient = prisma) {
+  await materializeCurrentEvaluations(userId, evaluator, db);
+  return withSqliteBusyRetry(() => db.$transaction(async (tx) => {
+    const now = new Date();
+    const candidates = await tx.jobEvaluation.findMany({
+      where: { userId, evaluatorKey: evaluator.evaluatorKey, evaluatorVersion: evaluator.evaluatorVersion, isCurrent: true, OR: [
+        { status: "pending" }, { status: "retry", nextAttemptAt: { lte: now } }, { status: "running", leaseExpiresAt: { lte: now } },
+      ] }, orderBy: { createdAt: "asc" }, take: batch,
+    });
+    const claimed = [];
+    for (const candidate of candidates) {
+      const leaseToken = randomUUID();
+      const leaseExpiresAt = new Date(now.getTime() + leaseMs);
+      const updated = await tx.jobEvaluation.updateMany({
+        where: { id: candidate.id, userId, isCurrent: true, OR: [
+          { status: "pending" }, { status: "retry", nextAttemptAt: { lte: now } }, { status: "running", leaseExpiresAt: { lte: now } },
+        ] },
+        data: { status: "running", attemptCount: { increment: 1 }, leaseToken, leaseExpiresAt, nextAttemptAt: null },
+      });
+      if (updated.count) claimed.push(await tx.jobEvaluation.findUniqueOrThrow({ where: { id: candidate.id } }));
+    }
+    return claimed;
+  }));
+}
+
+export async function completeEvaluation(userId: string, id: string, leaseToken: string, inputHash: string, result: Record<string, unknown>, db: PrismaClient = prisma) {
+  const resultJson = stableJson(result);
+  const resultHash = sha256(resultJson);
+  const row = await db.jobEvaluation.findFirst({ where: { id, userId } });
+  if (!row) return "missing" as const;
+  if (row.status === "succeeded" && row.leaseToken === leaseToken && row.inputHash === inputHash && row.resultHash === resultHash) return "idempotent" as const;
+  const updated = await db.jobEvaluation.updateMany({ where: { id, userId, status: "running", leaseToken, inputHash }, data: { status: "succeeded", resultJson, resultHash, evaluatedAt: new Date(), leaseExpiresAt: null, lastError: null } });
+  return updated.count ? "completed" as const : "conflict" as const;
+}
+
+export async function failEvaluation(userId: string, id: string, leaseToken: string, inputHash: string, error: string, db: PrismaClient = prisma) {
+  const row = await db.jobEvaluation.findFirst({ where: { id, userId } });
+  const lastError = error.trim().slice(0, 2000);
+  if (!row) return "missing" as const;
+  if ((row.status === "failed" || row.status === "retry") && row.leaseToken === leaseToken && row.inputHash === inputHash && row.lastError === lastError) return "idempotent" as const;
+  if (row.status !== "running" || row.leaseToken !== leaseToken || row.inputHash !== inputHash) return "conflict" as const;
+  const terminal = row.attemptCount >= MAX_ATTEMPTS;
+  await db.jobEvaluation.update({ where: { id }, data: { status: terminal ? "failed" : "retry", lastError, leaseExpiresAt: null, nextAttemptAt: terminal ? null : new Date(Date.now() + RETRY_DELAYS_MS[Math.min(row.attemptCount - 1, RETRY_DELAYS_MS.length - 1)]) } });
+  return terminal ? "failed" as const : "retry" as const;
+}

--- a/src/lib/jobs/resumeDetailInclude.ts
+++ b/src/lib/jobs/resumeDetailInclude.ts
@@ -23,6 +23,7 @@ export const resumeDetailInclude = {
         },
       },
       licenseOrCertifications: true,
+      others: true,
       skills: { include: { Tag: true } },
     },
   },

--- a/src/lib/mcp/auth.ts
+++ b/src/lib/mcp/auth.ts
@@ -1,10 +1,11 @@
 import prisma from "@/lib/db";
+import type { PrismaClient } from "@prisma/client";
 import { hashToken } from "./tokens";
 
 type AuthSuccess = { ok: true; userId: string; scopes: string[]; tokenName: string };
 type AuthFailure = { ok: false; status: 401 | 403; error: string };
 
-export async function resolveMcpToken(req: Request): Promise<AuthSuccess | AuthFailure> {
+export async function resolveMcpToken(req: Request, db: PrismaClient = prisma): Promise<AuthSuccess | AuthFailure> {
   const authHeader = req.headers.get("authorization") ?? "";
   if (!authHeader.startsWith("Bearer ")) {
     return { ok: false, status: 401, error: "Missing or malformed Authorization header" };
@@ -16,7 +17,7 @@ export async function resolveMcpToken(req: Request): Promise<AuthSuccess | AuthF
   }
 
   const tokenHash = hashToken(plaintext);
-  const record = await prisma.mcpAccessToken.findUnique({ where: { tokenHash } });
+  const record = await db.mcpAccessToken.findUnique({ where: { tokenHash } });
 
   if (!record) {
     return { ok: false, status: 401, error: "Invalid token" };
@@ -27,14 +28,18 @@ export async function resolveMcpToken(req: Request): Promise<AuthSuccess | AuthF
   }
 
   // Fire-and-forget lastUsedAt update
-  prisma.mcpAccessToken.update({
+  db.mcpAccessToken.update({
     where: { id: record.id },
     data: { lastUsedAt: new Date() },
   }).catch(() => {});
 
   let scopes: string[];
   try {
-    scopes = JSON.parse(record.scopes) as string[];
+    const parsed: unknown = JSON.parse(record.scopes);
+    if (!Array.isArray(parsed) || !parsed.every((scope) => typeof scope === "string")) {
+      return { ok: false, status: 401, error: "Malformed token scopes" };
+    }
+    scopes = parsed;
   } catch {
     return { ok: false, status: 401, error: "Malformed token scopes" };
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,6 +8,6 @@ export const config = {
   matcher: [
     "/dashboard",
     "/dashboard/:path*",
-    "/api/((?!auth|mcp).*)",
+    "/api/((?!auth|mcp|job-evaluations).*)",
   ],
 };

--- a/src/models/profile.model.ts
+++ b/src/models/profile.model.ts
@@ -96,7 +96,14 @@ export interface ResumeSection {
   workExperiences?: WorkExperience[];
   educations?: Education[];
   licenseOrCertifications?: LicenseOrCertification[];
+  others?: OtherSection[];
   skills?: Skill[];
+}
+
+export interface OtherSection {
+  id?: string;
+  title: string;
+  content: string;
 }
 
 export interface WorkExperience {


### PR DESCRIPTION
## Summary

Adds a durable, source-independent lifecycle for asynchronous job evaluations without blocking job ingestion or overloading the existing resume-match fields.

## Changes

- add versioned `JobEvaluation` persistence and migration
- canonicalize current persisted job and default-resume inputs server-side
- add leased claim, fenced complete/fail, retry, and current/history access APIs
- add a least-privilege `evaluations:worker` token preset
- preserve existing `Job.matchScore` and `Job.matchData` behavior

## Related Issues

Closes ROB-74
Closes Gsync/jobsync#100

## Testing

- `npx prisma generate`
- `DATABASE_URL="file:/tmp/jobsync-rob74-verify.db" npx prisma migrate deploy`
- `npx tsc --noEmit`
- `npm run lint`
- `npm test -- --run src/lib/jobEvaluations/service.test.ts`

This PR remains draft while the real-SQLite concurrency/auth/source integration matrix and final high-risk review are completed.
