### PR TITLE
feat: add integration job read API

### DIFF
--- a/__tests__/integrationJobsAuth.spec.ts
+++ b/__tests__/integrationJobsAuth.spec.ts
@@ -1,0 +1,108 @@
+import { authorizeIntegrationRead } from "@/lib/jobs/integrationRoute";
+import { resolveMcpToken } from "@/lib/mcp/auth";
+import { checkMcpRateLimit } from "@/lib/mcp/rate-limit";
+
+vi.mock("@/lib/mcp/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/mcp/auth")>();
+  return { ...actual, resolveMcpToken: vi.fn() };
+});
+
+vi.mock("@/lib/mcp/rate-limit", () => ({
+  checkMcpRateLimit: vi.fn(),
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number; headers?: Record<string, string> }) => ({
+      status: init?.status ?? 200,
+      headers: init?.headers ?? {},
+      json: async () => data,
+    }),
+  },
+}));
+
+const req = {} as Request;
+
+describe("integration jobs bearer authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (checkMcpRateLimit as any).mockReturnValue({
+      allowed: true,
+      remaining: 59,
+      resetIn: 60_000,
+    });
+  });
+
+  it("returns token authentication failures unchanged", async () => {
+    (resolveMcpToken as any).mockResolvedValue({
+      ok: false,
+      status: 401,
+      error: "Invalid token",
+    });
+
+    const result = await authorizeIntegrationRead(req);
+
+    expect("response" in result).toBe(true);
+    if (!("response" in result)) throw new Error("Expected error response");
+    const response = result.response;
+    if (!response) throw new Error("Expected error response");
+    expect(response.status).toBe(401);
+    expect(checkMcpRateLimit).not.toHaveBeenCalled();
+  });
+
+  it.each([["jobs:read"], ["jobs:write"]])(
+    "accepts compatible scope %s",
+    async (scope) => {
+      (resolveMcpToken as any).mockResolvedValue({
+        ok: true,
+        userId: "user-1",
+        scopes: [scope],
+        tokenName: "token",
+      });
+
+      await expect(authorizeIntegrationRead(req)).resolves.toEqual({ userId: "user-1" });
+      expect(checkMcpRateLimit).toHaveBeenCalledWith("user-1");
+    },
+  );
+
+  it("rejects unrelated scopes", async () => {
+    (resolveMcpToken as any).mockResolvedValue({
+      ok: true,
+      userId: "user-1",
+      scopes: ["questions:write"],
+      tokenName: "token",
+    });
+
+    const result = await authorizeIntegrationRead(req);
+
+    expect("response" in result).toBe(true);
+    if (!("response" in result)) throw new Error("Expected error response");
+    const response = result.response;
+    if (!response) throw new Error("Expected error response");
+    expect(response.status).toBe(403);
+    expect(checkMcpRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("applies the existing user-scoped MCP rate limit", async () => {
+    (resolveMcpToken as any).mockResolvedValue({
+      ok: true,
+      userId: "user-1",
+      scopes: ["jobs:read"],
+      tokenName: "token",
+    });
+    (checkMcpRateLimit as any).mockReturnValue({
+      allowed: false,
+      remaining: 0,
+      resetIn: 1_500,
+    });
+
+    const result = await authorizeIntegrationRead(req);
+
+    expect("response" in result).toBe(true);
+    if (!("response" in result)) throw new Error("Expected error response");
+    const response = result.response;
+    if (!response) throw new Error("Expected error response");
+    expect(response.status).toBe(429);
+    expect(response.headers).toEqual({ "Retry-After": "2" });
+  });
+});

--- a/__tests__/integrationJobsRoutes.spec.ts
+++ b/__tests__/integrationJobsRoutes.spec.ts
@@ -1,0 +1,116 @@
+import { authorizeIntegrationRead } from "@/lib/jobs/integrationRoute";
+import {
+  getIntegrationResumeSnapshot,
+  getOwnedIntegrationJob,
+  listIntegrationJobs,
+} from "@/lib/jobs/integrationRead";
+
+vi.mock("@/lib/jobs/integrationRoute", () => ({
+  authorizeIntegrationRead: vi.fn(),
+}));
+
+vi.mock("@/lib/jobs/integrationRead", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/jobs/integrationRead")>();
+  return {
+    ...actual,
+    getIntegrationResumeSnapshot: vi.fn(),
+    getOwnedIntegrationJob: vi.fn(),
+    listIntegrationJobs: vi.fn(),
+  };
+});
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+import { GET as listJobs } from "@/app/api/integrations/jobs/route";
+import { GET as getJob } from "@/app/api/integrations/jobs/[id]/route";
+
+describe("JobSync integration job routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (authorizeIntegrationRead as any).mockResolvedValue({ userId: "user-1" });
+  });
+
+  it("returns a compact page and resume fingerprint without raw content", async () => {
+    (listIntegrationJobs as any).mockResolvedValue({
+      jobs: [{ id: "job-1", fingerprint: "job-hash", descriptionCompleteness: "full" }],
+      nextCursor: null,
+    });
+    (getIntegrationResumeSnapshot as any).mockResolvedValue({
+      id: "resume-1",
+      title: "Default Resume",
+      fingerprint: "resume-hash",
+    });
+    const request = { url: "https://jobsync.test/api/integrations/jobs?limit=25" } as Request;
+
+    const response = await listJobs(request);
+    if (!response) throw new Error("Expected response");
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(listIntegrationJobs).toHaveBeenCalledWith("user-1", undefined, 25);
+    expect(getIntegrationResumeSnapshot).toHaveBeenCalledWith("user-1", false);
+    expect(data.jobs[0]).not.toHaveProperty("description");
+    expect(data.defaultResume).not.toHaveProperty("content");
+  });
+
+  it("returns 400 for invalid pagination without querying jobs", async () => {
+    const request = { url: "https://jobsync.test/api/integrations/jobs?limit=0" } as Request;
+
+    const response = await listJobs(request);
+    if (!response) throw new Error("Expected response");
+
+    expect(response.status).toBe(400);
+    expect(listIntegrationJobs).not.toHaveBeenCalled();
+  });
+
+  it("reads a job only through the authenticated user's owned lookup", async () => {
+    (getOwnedIntegrationJob as any).mockResolvedValue({
+      id: "job-1",
+      jobUrl: null,
+      title: "Staff Engineer",
+      company: "Example Co",
+      location: null,
+      workplaceType: null,
+      jobType: "full-time",
+      salaryRange: null,
+      descriptionCompleteness: "full",
+      description: "Complete description",
+      fingerprint: "job-hash",
+    });
+    (getIntegrationResumeSnapshot as any).mockResolvedValue({
+      id: "resume-1",
+      title: "Default Resume",
+      fingerprint: "resume-hash",
+      content: "Normalized resume",
+    });
+
+    const response = await getJob({} as Request, {
+      params: Promise.resolve({ id: "job-1" }),
+    });
+    if (!response) throw new Error("Expected response");
+    const data = await response.json();
+
+    expect(getOwnedIntegrationJob).toHaveBeenCalledWith("user-1", "job-1");
+    expect(data.job.jobUrl).toBeNull();
+    expect(data.defaultResume.content).toBe("Normalized resume");
+  });
+
+  it("returns the same 404 for missing or foreign-owned job IDs", async () => {
+    (getOwnedIntegrationJob as any).mockResolvedValue(null);
+
+    const response = await getJob({} as Request, {
+      params: Promise.resolve({ id: "foreign-job" }),
+    });
+    if (!response) throw new Error("Expected response");
+
+    expect(response.status).toBe(404);
+    expect(getIntegrationResumeSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/integrationJobsSerialization.spec.ts
+++ b/__tests__/integrationJobsSerialization.spec.ts
@@ -1,0 +1,208 @@
+import {
+  getIntegrationResumeSnapshot,
+  getOwnedIntegrationJob,
+  listIntegrationJobs,
+  normalizeJobDescription,
+  parseIntegrationJobsQuery,
+  serializeIntegrationJob,
+} from "@/lib/jobs/integrationRead";
+import prisma from "@/lib/db";
+import { getDefaultResumeForUser } from "@/lib/jobs/getDefaultResumeForUser";
+
+vi.mock("@/lib/db", () => ({
+  default: {
+    job: { findMany: vi.fn(), findFirst: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/jobs/getDefaultResumeForUser", () => ({
+  getDefaultResumeForUser: vi.fn(),
+}));
+
+const job = (overrides: Record<string, unknown> = {}) => ({
+  id: "job-1",
+  jobUrl: null,
+  description: "<p>Build reliable systems</p><ul><li>Own APIs</li></ul>",
+  jobType: "full-time",
+  workplaceType: null,
+  salaryRange: null,
+  descriptionCompleteness: "full",
+  JobTitle: { label: "Staff Engineer" },
+  Company: { label: "Example Co" },
+  Location: null,
+  ...overrides,
+});
+
+describe("JobSync integration serialization", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("normalizes stored HTML and rendered markdown to the same plain text", () => {
+    const html = "<p>Build reliable systems</p><ul><li>Own APIs</li></ul>";
+    const rawMarkdown = "Build reliable systems\n\n- Own APIs";
+
+    expect(normalizeJobDescription(html)).toBe(
+      normalizeJobDescription(rawMarkdown),
+    );
+    expect(normalizeJobDescription(html)).not.toContain("<p>");
+  });
+
+  it("preserves nullable persisted fields and computes missing completeness", () => {
+    const serialized = serializeIntegrationJob(
+      job({
+        description: "<p>Short posting</p>",
+        descriptionCompleteness: null,
+      }) as any,
+    );
+
+    expect(serialized).toMatchObject({
+      jobUrl: null,
+      location: null,
+      workplaceType: null,
+      salaryRange: null,
+      description: "Short posting",
+      descriptionCompleteness: "title-only",
+    });
+  });
+
+  it.each([
+    ["jobUrl", { jobUrl: "https://example.com/jobs/1" }],
+    ["title", { JobTitle: { label: "Principal Engineer" } }],
+    ["company", { Company: { label: "Different Co" } }],
+    ["location", { Location: { label: "New York, NY" } }],
+    ["workplace type", { workplaceType: "hybrid" }],
+    ["job type", { jobType: "contract" }],
+    ["salary", { salaryRange: "$200k-$240k" }],
+    ["completeness", { descriptionCompleteness: "partial" }],
+    ["description", { description: "<p>Different description</p>" }],
+  ])("changes the job fingerprint when %s changes", (_field, overrides) => {
+    expect(serializeIntegrationJob(job() as any).fingerprint).not.toBe(
+      serializeIntegrationJob(job(overrides) as any).fingerprint,
+    );
+  });
+
+  it("uses stable ID keyset pagination without returning descriptions", async () => {
+    (prisma.job.findMany as any).mockResolvedValue([
+      job({ id: "job-2" }),
+      job({ id: "job-3" }),
+      job({ id: "job-4" }),
+    ]);
+
+    const page = await listIntegrationJobs("user-1", "job-1", 2);
+
+    expect(prisma.job.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { userId: "user-1", id: { gt: "job-1" } },
+      orderBy: { id: "asc" },
+      take: 3,
+    }));
+    expect(page.jobs).toHaveLength(2);
+    expect(page.jobs[0]).not.toHaveProperty("description");
+    expect(page.nextCursor).toEqual(expect.any(String));
+
+    const next = parseIntegrationJobsQuery(
+      `https://jobsync.test/api/integrations/jobs?cursor=${page.nextCursor}&limit=2`,
+    );
+    expect(next).toEqual({ cursorId: "job-3", limit: 2 });
+  });
+
+  it("scopes detail reads by both stable ID and authenticated user ID", async () => {
+    (prisma.job.findFirst as any).mockResolvedValue(null);
+
+    await expect(getOwnedIntegrationJob("user-1", "job-1")).resolves.toBeNull();
+
+    expect(prisma.job.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: "job-1", userId: "user-1" },
+    }));
+  });
+
+  it.each([
+    "https://jobsync.test/api/integrations/jobs?limit=0",
+    "https://jobsync.test/api/integrations/jobs?limit=101",
+    "https://jobsync.test/api/integrations/jobs?limit=1.5",
+    "https://jobsync.test/api/integrations/jobs?cursor=not-a-cursor",
+  ])("rejects invalid pagination input: %s", (url) => {
+    expect(() => parseIntegrationJobsQuery(url)).toThrow();
+  });
+
+  it("fingerprints normalized default-resume content plus identity and title", async () => {
+    const resume = {
+      id: "resume-1",
+      title: "Default Resume",
+      ContactInfo: {
+        firstName: "Robert",
+        lastName: "Nguyen",
+        headline: "Engineer",
+        email: "robert@example.com",
+        phone: "555-555-5555",
+        address: "New York, NY",
+      },
+      ResumeSections: [{
+        id: "section-1",
+        resumeId: "resume-1",
+        sectionTitle: "Summary",
+        sectionType: "summary",
+        summary: { content: "Builds reliable products" },
+      }],
+    };
+    (getDefaultResumeForUser as any).mockResolvedValue(resume);
+
+    const first = await getIntegrationResumeSnapshot("user-1", true);
+    (getDefaultResumeForUser as any).mockResolvedValue({
+      ...resume,
+      ResumeSections: [{
+        ...resume.ResumeSections[0],
+        summary: { content: "Builds reliable products and platforms" },
+      }],
+    });
+    const contentChanged = await getIntegrationResumeSnapshot("user-1", true);
+    (getDefaultResumeForUser as any).mockResolvedValue({
+      ...resume,
+      title: "Updated Resume",
+    });
+    const titleChanged = await getIntegrationResumeSnapshot("user-1", false);
+
+    expect(first?.content).toContain("Builds reliable products");
+    expect(first?.fingerprint).not.toBe(contentChanged?.fingerprint);
+    expect(first?.fingerprint).not.toBe(titleChanged?.fingerprint);
+    expect(titleChanged).not.toHaveProperty("content");
+  });
+
+  it("makes resume fingerprints independent of relation query order", async () => {
+    const sections = [
+      {
+        id: "section-b",
+        resumeId: "resume-1",
+        sectionTitle: "Projects",
+        sectionType: "project",
+        others: [
+          { id: "project-b", title: "Beta", content: "Second project" },
+          { id: "project-a", title: "Alpha", content: "First project" },
+        ],
+      },
+      {
+        id: "section-a",
+        resumeId: "resume-1",
+        sectionTitle: "Summary",
+        sectionType: "summary",
+        summary: { content: "Builds reliable products" },
+      },
+    ];
+    (getDefaultResumeForUser as any).mockResolvedValue({
+      id: "resume-1",
+      title: "Default Resume",
+      ResumeSections: sections,
+    });
+    const first = await getIntegrationResumeSnapshot("user-1", true);
+    (getDefaultResumeForUser as any).mockResolvedValue({
+      id: "resume-1",
+      title: "Default Resume",
+      ResumeSections: [...sections].reverse().map((section) => ({
+        ...section,
+        others: section.others ? [...section.others].reverse() : undefined,
+      })),
+    });
+    const reordered = await getIntegrationResumeSnapshot("user-1", true);
+
+    expect(first?.content).toContain("First project");
+    expect(first?.fingerprint).toBe(reordered?.fingerprint);
+  });
+});

--- a/__tests__/mcpAuth.spec.ts
+++ b/__tests__/mcpAuth.spec.ts
@@ -90,6 +90,24 @@ describe("resolveMcpToken", () => {
     });
   });
 
+  it("rejects valid JSON that is not an array of string scopes", async () => {
+    (prisma.mcpAccessToken.findUnique as any).mockResolvedValue({
+      id: "t-1",
+      userId: "user-1",
+      scopes: JSON.stringify(["jobs:write", 42]),
+      name: "my-token",
+      expiresAt: new Date(Date.now() + 1000 * 60 * 60),
+    });
+
+    const result = await resolveMcpToken(makeRequest("Bearer jsync_bad-scope-type"));
+
+    expect(result).toEqual({
+      ok: false,
+      status: 401,
+      error: "Malformed token scopes",
+    });
+  });
+
   it("accepts a valid token and looks it up by its hash", async () => {
     const plaintext = "jsync_valid-token";
     (prisma.mcpAccessToken.findUnique as any).mockResolvedValue({

--- a/__tests__/mcpTokenActions.spec.ts
+++ b/__tests__/mcpTokenActions.spec.ts
@@ -1,0 +1,53 @@
+import { createMcpToken } from "@/actions/mcpToken.actions";
+import prisma from "@/lib/db";
+import { getCurrentUser } from "@/utils/user.utils";
+import { generateToken } from "@/lib/mcp/tokens";
+
+vi.mock("@/lib/db", () => ({
+  default: {
+    mcpAccessToken: {
+      count: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/utils/user.utils", () => ({
+  getCurrentUser: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp/tokens", () => ({
+  generateToken: vi.fn(),
+}));
+
+describe("createMcpToken", () => {
+  it("grants new tokens explicit read access while retaining write scopes", async () => {
+    (getCurrentUser as any).mockResolvedValue({ id: "user-1" });
+    (prisma.mcpAccessToken.count as any).mockResolvedValue(0);
+    (generateToken as any).mockReturnValue({
+      plaintext: "jsync_plaintext",
+      hash: "token-hash",
+      prefix: "jsync_plain",
+    });
+    (prisma.mcpAccessToken.create as any).mockImplementation(({ data }: any) => ({
+      id: "token-1",
+      ...data,
+      lastUsedAt: null,
+      createdAt: new Date("2026-08-16T00:00:00Z"),
+    }));
+
+    const result = await createMcpToken({ name: "Windmill", expiryDays: 90 });
+
+    expect(result.success).toBe(true);
+    expect(prisma.mcpAccessToken.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        scopes: JSON.stringify([
+          "jobs:read",
+          "jobs:write",
+          "questions:write",
+          "resume:write",
+        ]),
+      }),
+    });
+  });
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -521,7 +521,7 @@ model McpAccessToken {
   name        String
   tokenHash   String    @unique
   tokenPrefix String
-  scopes      String    // JSON array string; new tokens are always ["jobs:write","questions:write","resume:write"]
+  scopes      String    // JSON array string; new tokens include jobs:read plus existing write scopes
   expiresAt   DateTime
   lastUsedAt  DateTime?
   createdAt   DateTime  @default(now())

--- a/src/actions/mcpToken.actions.ts
+++ b/src/actions/mcpToken.actions.ts
@@ -44,7 +44,7 @@ export async function createMcpToken(input: {
         name: input.name.trim(),
         tokenHash: hash,
         tokenPrefix: prefix,
-        scopes: JSON.stringify(["jobs:write", "questions:write", "resume:write"]),
+        scopes: JSON.stringify(["jobs:read", "jobs:write", "questions:write", "resume:write"]),
         expiresAt,
       },
     });

--- a/src/app/api/integrations/jobs/[id]/route.ts
+++ b/src/app/api/integrations/jobs/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import {
+  getIntegrationResumeSnapshot,
+  getOwnedIntegrationJob,
+} from "@/lib/jobs/integrationRead";
+import { authorizeIntegrationRead } from "@/lib/jobs/integrationRoute";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authorization = await authorizeIntegrationRead(req);
+  if ("response" in authorization) return authorization.response;
+
+  try {
+    const { id } = await params;
+    const job = await getOwnedIntegrationJob(authorization.userId, id);
+    if (!job) {
+      return NextResponse.json({ error: "Job not found" }, { status: 404 });
+    }
+    const defaultResume = await getIntegrationResumeSnapshot(authorization.userId, true);
+    return NextResponse.json({ job, defaultResume });
+  } catch (error) {
+    console.error("Failed to read integration job:", error);
+    return NextResponse.json({ error: "Failed to read job" }, { status: 500 });
+  }
+}

--- a/src/app/api/integrations/jobs/route.ts
+++ b/src/app/api/integrations/jobs/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import {
+  getIntegrationResumeSnapshot,
+  listIntegrationJobs,
+  parseIntegrationJobsQuery,
+} from "@/lib/jobs/integrationRead";
+import { authorizeIntegrationRead } from "@/lib/jobs/integrationRoute";
+
+export async function GET(req: Request) {
+  const authorization = await authorizeIntegrationRead(req);
+  if ("response" in authorization) return authorization.response;
+
+  try {
+    const { cursorId, limit } = parseIntegrationJobsQuery(req.url);
+    const [page, defaultResume] = await Promise.all([
+      listIntegrationJobs(authorization.userId, cursorId, limit),
+      getIntegrationResumeSnapshot(authorization.userId, false),
+    ]);
+    return NextResponse.json({ defaultResume, ...page });
+  } catch (error) {
+    if (error instanceof Error && (error.message.startsWith("limit") || error.message.startsWith("cursor"))) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    console.error("Failed to list integration jobs:", error);
+    return NextResponse.json({ error: "Failed to list jobs" }, { status: 500 });
+  }
+}

--- a/src/lib/ai/tools/preprocessing.ts
+++ b/src/lib/ai/tools/preprocessing.ts
@@ -8,6 +8,7 @@ import {
   ContactInfo,
   Education,
   LicenseOrCertification,
+  OtherSection,
   Resume,
   ResumeSection,
   SectionType,
@@ -179,6 +180,17 @@ export const convertResumeToText = (resume: Resume): Promise<string> => {
         .join("\n\n");
     };
 
+    const formatOtherSections = (items?: OtherSection[]) => {
+      if (!items || items.length === 0) return "";
+      return items
+        .map((item) => {
+          const content = removeHtmlTags(item.content);
+          return content ? `${item.title}\n${content}` : "";
+        })
+        .filter(Boolean)
+        .join("\n\n");
+    };
+
     const SECTION_ORDER: Record<string, number> = {
       [SectionType.SUMMARY]: 0,
       [SectionType.SKILLS]: 1,
@@ -234,6 +246,14 @@ export const convertResumeToText = (resume: Resume): Promise<string> => {
                 return cat ? `${cat}: ${labels}` : labels;
               });
               return `## ${section.sectionTitle.toUpperCase()}\n${lines.join("\n")}`;
+            }
+            case SectionType.COURSE:
+            case SectionType.PROJECT:
+            case SectionType.OTHER: {
+              const content = formatOtherSections(section.others);
+              return content
+                ? `## ${section.sectionTitle.toUpperCase()}\n${content}`
+                : "";
             }
             default:
               return "";

--- a/src/lib/jobs/integrationRead.ts
+++ b/src/lib/jobs/integrationRead.ts
@@ -1,0 +1,218 @@
+import { createHash } from "crypto";
+import MarkdownIt from "markdown-it";
+import prisma from "@/lib/db";
+import { convertResumeToText } from "@/lib/ai/tools/preprocessing";
+import {
+  normalizeBullets,
+  normalizeHeadings,
+  normalizeWhitespace,
+  removeHtmlTags,
+} from "@/lib/ai/tools/text-processing";
+import { classifyDescriptionCompleteness } from "@/lib/jobs/descriptionCompleteness";
+import { getDefaultResumeForUser } from "@/lib/jobs/getDefaultResumeForUser";
+import type { DescriptionCompleteness } from "@/models/job.model";
+import type { Resume } from "@/models/profile.model";
+
+const DEFAULT_LIMIT = 100;
+export const MAX_INTEGRATION_JOBS_LIMIT = 100;
+const markdown = new MarkdownIt({ html: false, linkify: false, breaks: true });
+
+const jobSelect = {
+  id: true,
+  jobUrl: true,
+  description: true,
+  jobType: true,
+  workplaceType: true,
+  salaryRange: true,
+  descriptionCompleteness: true,
+  JobTitle: { select: { label: true } },
+  Company: { select: { label: true } },
+  Location: { select: { label: true } },
+} as const;
+
+type IntegrationJobRecord = {
+  id: string;
+  jobUrl: string | null;
+  description: string;
+  jobType: string;
+  workplaceType: string | null;
+  salaryRange: string | null;
+  descriptionCompleteness: string | null;
+  JobTitle: { label: string };
+  Company: { label: string };
+  Location: { label: string } | null;
+};
+
+export interface IntegrationResumeSnapshot {
+  id: string;
+  title: string;
+  fingerprint: string;
+  content?: string;
+}
+
+export interface IntegrationJobDetail {
+  id: string;
+  jobUrl: string | null;
+  title: string;
+  company: string;
+  location: string | null;
+  workplaceType: string | null;
+  jobType: string;
+  salaryRange: string | null;
+  descriptionCompleteness: DescriptionCompleteness;
+  description: string;
+  fingerprint: string;
+}
+
+function fingerprint(namespace: string, value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify([namespace, value]))
+    .digest("hex");
+}
+
+export function normalizeJobDescription(description: string): string {
+  const html = /<\/?[a-z][\s\S]*>/i.test(description)
+    ? description
+    : markdown.render(description);
+  return normalizeHeadings(
+    normalizeBullets(normalizeWhitespace(removeHtmlTags(html))),
+  );
+}
+
+function sortById<T extends { id?: string }>(items: T[] | undefined): T[] | undefined {
+  return items ? [...items].sort((a, b) => (a.id ?? "").localeCompare(b.id ?? "")) : items;
+}
+
+function canonicalizeResume(resume: Resume): Resume {
+  return {
+    ...resume,
+    ResumeSections: sortById(resume.ResumeSections)?.map((section) => ({
+      ...section,
+      workExperiences: sortById(section.workExperiences),
+      educations: sortById(section.educations),
+      licenseOrCertifications: sortById(section.licenseOrCertifications),
+      others: sortById(section.others),
+      skills: section.skills
+        ? [...section.skills].sort(
+            (a, b) => a.order - b.order || (a.id ?? "").localeCompare(b.id ?? ""),
+          )
+        : section.skills,
+    })),
+  };
+}
+
+export function serializeIntegrationJob(
+  job: IntegrationJobRecord,
+): IntegrationJobDetail {
+  const description = normalizeJobDescription(job.description);
+  const descriptionCompleteness = (
+    job.descriptionCompleteness ?? classifyDescriptionCompleteness(description)
+  ) as DescriptionCompleteness;
+  const detail = {
+    id: job.id,
+    jobUrl: job.jobUrl,
+    title: job.JobTitle.label,
+    company: job.Company.label,
+    location: job.Location?.label ?? null,
+    workplaceType: job.workplaceType,
+    jobType: job.jobType,
+    salaryRange: job.salaryRange,
+    descriptionCompleteness,
+    description,
+  };
+
+  return {
+    ...detail,
+    fingerprint: fingerprint("jobsync-job-v1", detail),
+  };
+}
+
+function encodeCursor(id: string): string {
+  return Buffer.from(JSON.stringify({ v: 1, id }), "utf8").toString("base64url");
+}
+
+export function parseIntegrationJobsQuery(url: string): {
+  cursorId?: string;
+  limit: number;
+} {
+  const { searchParams } = new URL(url);
+  const limitValue = searchParams.get("limit");
+  const cursorValue = searchParams.get("cursor");
+  const limit = limitValue === null ? DEFAULT_LIMIT : Number(limitValue);
+
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_INTEGRATION_JOBS_LIMIT) {
+    throw new Error(`limit must be an integer from 1 to ${MAX_INTEGRATION_JOBS_LIMIT}`);
+  }
+
+  if (!cursorValue) return { limit };
+
+  try {
+    const parsed = JSON.parse(Buffer.from(cursorValue, "base64url").toString("utf8"));
+    if (parsed?.v !== 1 || typeof parsed.id !== "string" || !parsed.id) {
+      throw new Error("Invalid cursor");
+    }
+    return { cursorId: parsed.id, limit };
+  } catch {
+    throw new Error("cursor is invalid");
+  }
+}
+
+export async function getIntegrationResumeSnapshot(
+  userId: string,
+  includeContent: boolean,
+): Promise<IntegrationResumeSnapshot | null> {
+  const resume = await getDefaultResumeForUser(userId);
+  if (!resume?.id) return null;
+
+  const content = normalizeHeadings(
+    normalizeBullets(
+      normalizeWhitespace(await convertResumeToText(canonicalizeResume(resume))),
+    ),
+  );
+  const snapshot: IntegrationResumeSnapshot = {
+    id: resume.id,
+    title: resume.title,
+    fingerprint: fingerprint("jobsync-resume-v1", {
+      id: resume.id,
+      title: resume.title,
+      content,
+    }),
+  };
+
+  return includeContent ? { ...snapshot, content } : snapshot;
+}
+
+export async function listIntegrationJobs(
+  userId: string,
+  cursorId: string | undefined,
+  limit: number,
+) {
+  const records = await prisma.job.findMany({
+    where: {
+      userId,
+      ...(cursorId ? { id: { gt: cursorId } } : {}),
+    },
+    orderBy: { id: "asc" },
+    take: limit + 1,
+    select: jobSelect,
+  });
+  const hasMore = records.length > limit;
+  const page = records.slice(0, limit).map(serializeIntegrationJob);
+
+  return {
+    jobs: page.map(({ id, fingerprint: jobFingerprint, descriptionCompleteness }) => ({
+      id,
+      fingerprint: jobFingerprint,
+      descriptionCompleteness,
+    })),
+    nextCursor: hasMore && page.length > 0 ? encodeCursor(page[page.length - 1].id) : null,
+  };
+}
+
+export async function getOwnedIntegrationJob(userId: string, id: string) {
+  const record = await prisma.job.findFirst({
+    where: { id, userId },
+    select: jobSelect,
+  });
+  return record ? serializeIntegrationJob(record) : null;
+}

--- a/src/lib/jobs/integrationRoute.ts
+++ b/src/lib/jobs/integrationRoute.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { hasMcpScope, resolveMcpToken } from "@/lib/mcp/auth";
+import { checkMcpRateLimit } from "@/lib/mcp/rate-limit";
+
+export async function authorizeIntegrationRead(req: Request) {
+  const auth = await resolveMcpToken(req);
+  if (!auth.ok) {
+    return {
+      response: NextResponse.json({ error: auth.error }, { status: auth.status }),
+    } as const;
+  }
+  if (!hasMcpScope(auth.scopes, "jobs:read")) {
+    return {
+      response: NextResponse.json(
+        { error: "Insufficient scope. Required: jobs:read" },
+        { status: 403 },
+      ),
+    } as const;
+  }
+
+  const rateLimit = checkMcpRateLimit(auth.userId);
+  if (!rateLimit.allowed) {
+    return {
+      response: NextResponse.json(
+        { error: "Rate limit exceeded" },
+        {
+          status: 429,
+          headers: { "Retry-After": String(Math.ceil(rateLimit.resetIn / 1000)) },
+        },
+      ),
+    } as const;
+  }
+
+  return { userId: auth.userId } as const;
+}

--- a/src/lib/jobs/resumeDetailInclude.ts
+++ b/src/lib/jobs/resumeDetailInclude.ts
@@ -23,6 +23,7 @@ export const resumeDetailInclude = {
         },
       },
       licenseOrCertifications: true,
+      others: true,
       skills: { include: { Tag: true } },
     },
   },

--- a/src/lib/mcp/auth.ts
+++ b/src/lib/mcp/auth.ts
@@ -4,6 +4,11 @@ import { hashToken } from "./tokens";
 type AuthSuccess = { ok: true; userId: string; scopes: string[]; tokenName: string };
 type AuthFailure = { ok: false; status: 401 | 403; error: string };
 
+export function hasMcpScope(scopes: string[], requiredScope: string): boolean {
+  return scopes.includes(requiredScope) ||
+    (requiredScope === "jobs:read" && scopes.includes("jobs:write"));
+}
+
 export async function resolveMcpToken(req: Request): Promise<AuthSuccess | AuthFailure> {
   const authHeader = req.headers.get("authorization") ?? "";
   if (!authHeader.startsWith("Bearer ")) {
@@ -34,7 +39,11 @@ export async function resolveMcpToken(req: Request): Promise<AuthSuccess | AuthF
 
   let scopes: string[];
   try {
-    scopes = JSON.parse(record.scopes) as string[];
+    const parsedScopes = JSON.parse(record.scopes) as unknown;
+    if (!Array.isArray(parsedScopes) || !parsedScopes.every((scope) => typeof scope === "string")) {
+      throw new Error("Invalid scopes");
+    }
+    scopes = parsedScopes;
   } catch {
     return { ok: false, status: 401, error: "Malformed token scopes" };
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,6 +8,6 @@ export const config = {
   matcher: [
     "/dashboard",
     "/dashboard/:path*",
-    "/api/((?!auth|mcp).*)",
+    "/api/((?!auth|mcp|integrations/jobs(?:/|$)).*)",
   ],
 };

--- a/src/models/profile.model.ts
+++ b/src/models/profile.model.ts
@@ -96,7 +96,14 @@ export interface ResumeSection {
   workExperiences?: WorkExperience[];
   educations?: Education[];
   licenseOrCertifications?: LicenseOrCertification[];
+  others?: OtherSection[];
   skills?: Skill[];
+}
+
+export interface OtherSection {
+  id?: string;
+  title: string;
+  content: string;
 }
 
 export interface WorkExperience {


### PR DESCRIPTION
## Summary

- add bearer-authenticated `GET /api/integrations/jobs` compact cursor index with job/default-resume fingerprints
- add owned `GET /api/integrations/jobs/:id` detail reads with normalized job and resume text
- add `jobs:read` issuance while keeping existing `jobs:write` tokens read-compatible
- preserve nullable posting fields, compute missing description completeness at read time, and cover nested resume content without a schema migration

## Why

This establishes the smallest supported read boundary for scheduled external evaluators without transmitting every full description on every poll or adding an evaluation lifecycle to JobSync.

## Verification

- `npm test` - 180 files, 2,194 tests passed
- `npm run lint` - passed
- `npm run build` - passed (existing dependency warnings only)
- `npx tsc --noEmit` - passed
- focused integration/auth suite - 5 files, 39 tests passed
- `git diff --cached --check` - passed before commit

## Residual Risk

A deployed authenticated smoke test against a real token and database remains for the consuming integration. No Prisma migration is included or required.

## Tracking

ROB-124
