### PR TITLE
feat(settings): add option to use 24hr clock (#112)

### DIFF
--- a/__tests__/TimePicker.spec.tsx
+++ b/__tests__/TimePicker.spec.tsx
@@ -3,6 +3,7 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useForm } from "react-hook-form";
 import { Form, FormField, FormItem } from "@/components/ui/form";
+import { ClockFormat } from "@/models/userSettings.model";
 
 // jsdom lacks scrollIntoView; the columns also read layout boxes on open
 Element.prototype.scrollIntoView = vi.fn();
@@ -13,9 +14,11 @@ const user = userEvent.setup({ skipHover: true });
 // the same way it is used in ActivityForm.
 function Harness({
   initialValue = "09:05 AM",
+  clockFormat = "12h",
   onChange = vi.fn(),
 }: {
   initialValue?: string;
+  clockFormat?: ClockFormat;
   onChange?: (value: string) => void;
 }) {
   const form = useForm({
@@ -32,6 +35,7 @@ function Harness({
         render={({ field }) => (
           <FormItem>
             <TimePicker
+              clockFormat={clockFormat}
               field={{
                 ...field,
                 onChange: (value: string) => {
@@ -50,142 +54,225 @@ function Harness({
 
 const column = (name: string) => within(screen.getByRole("group", { name }));
 
-async function openPicker(initialValue?: string) {
+async function openPicker(
+  initialValue = "09:05 AM",
+  clockFormat: ClockFormat = "12h"
+) {
   const onChange = vi.fn();
-  render(<Harness initialValue={initialValue} onChange={onChange} />);
+  render(
+    <Harness
+      initialValue={initialValue}
+      clockFormat={clockFormat}
+      onChange={onChange}
+    />
+  );
   await user.click(
-    screen.getByRole("button", { name: initialValue === "" ? "Pick a time" : "09:05 AM" })
+    screen.getByRole("button", {
+      name: initialValue === "" ? "Pick a time" : initialValue,
+    })
   );
   return { onChange };
 }
 
 describe("TimePicker", () => {
-  it("shows the current value on the trigger", () => {
-    render(<Harness />);
+  describe("12-hour mode", () => {
+    it("shows the current value on the trigger", () => {
+      render(<Harness />);
 
-    expect(
-      screen.getByRole("button", { name: "09:05 AM" })
-    ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "09:05 AM" })
+      ).toBeInTheDocument();
+    });
+
+    it("prompts when there is no value yet", () => {
+      render(<Harness initialValue="" />);
+
+      expect(
+        screen.getByRole("button", { name: "Pick a time" })
+      ).toBeInTheDocument();
+    });
+
+    it("marks the current parts as pressed when opened", async () => {
+      await openPicker();
+
+      expect(column("Hour").getByRole("button", { name: "09" })).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+      expect(column("Minute").getByRole("button", { name: "05" })).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+      expect(column("AM/PM").getByRole("button", { name: "AM" })).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+    });
+
+    it("keeps the minute and meridiem when the hour changes", async () => {
+      const { onChange } = await openPicker();
+
+      await user.click(column("Hour").getByRole("button", { name: "11" }));
+
+      expect(onChange).toHaveBeenCalledWith("11:05 AM");
+    });
+
+    it("keeps the hour and meridiem when the minute changes", async () => {
+      const { onChange } = await openPicker();
+
+      await user.click(column("Minute").getByRole("button", { name: "42" }));
+
+      expect(onChange).toHaveBeenCalledWith("09:42 AM");
+    });
+
+    it("keeps the hour and minute when the meridiem changes", async () => {
+      const { onChange } = await openPicker();
+
+      await user.click(column("AM/PM").getByRole("button", { name: "PM" }));
+
+      expect(onChange).toHaveBeenCalledWith("09:05 PM");
+    });
+
+    it("emits a padded value the schema regex accepts", async () => {
+      const { onChange } = await openPicker("");
+
+      await user.click(column("Hour").getByRole("button", { name: "03" }));
+
+      // Unset parts fall back to 12:00 AM rather than emitting a partial string
+      expect(onChange).toHaveBeenCalledWith("03:00 AM");
+      expect(onChange.mock.calls[0][0]).toMatch(
+        /^(?:(0[1-9]|1[0-2]):[0-5][0-9] (AM|PM)|([01][0-9]|2[0-3]):[0-5][0-9])$/
+      );
+    });
+
+    it("reflects the new value on the trigger", async () => {
+      await openPicker();
+
+      await user.click(column("AM/PM").getByRole("button", { name: "PM" }));
+      // The popover is modal, so the trigger stays aria-hidden until it closes
+      await user.keyboard("{Escape}");
+
+      expect(
+        screen.getByRole("button", { name: "09:05 PM" })
+      ).toBeInTheDocument();
+    });
+
+    it("steps the time forward and back by five minutes", async () => {
+      const onChange = vi.fn();
+      render(<Harness onChange={onChange} />);
+
+      await user.click(screen.getByRole("button", { name: "5 minutes later" }));
+      expect(onChange).toHaveBeenLastCalledWith("09:10 AM");
+
+      await user.click(screen.getByRole("button", { name: "5 minutes earlier" }));
+      expect(onChange).toHaveBeenLastCalledWith("09:05 AM");
+    });
+
+    it("wraps the clock when a step crosses midnight", async () => {
+      const onChange = vi.fn();
+      render(<Harness initialValue="11:58 PM" onChange={onChange} />);
+
+      await user.click(screen.getByRole("button", { name: "5 minutes later" }));
+
+      expect(onChange).toHaveBeenLastCalledWith("12:03 AM");
+    });
+
+    it("wraps backwards across midnight too", async () => {
+      const onChange = vi.fn();
+      render(<Harness initialValue="12:02 AM" onChange={onChange} />);
+
+      await user.click(screen.getByRole("button", { name: "5 minutes earlier" }));
+
+      expect(onChange).toHaveBeenLastCalledWith("11:57 PM");
+    });
+
+    it("steps from midnight when there is no value yet", async () => {
+      const onChange = vi.fn();
+      render(<Harness initialValue="" onChange={onChange} />);
+
+      await user.click(screen.getByRole("button", { name: "5 minutes later" }));
+
+      expect(onChange).toHaveBeenLastCalledWith("12:05 AM");
+    });
+
+    it("marks the field touched once the trigger loses focus", async () => {
+      render(<Harness />);
+      expect(screen.getByTestId("touched")).toHaveTextContent("false");
+
+      await user.click(screen.getByRole("button", { name: "09:05 AM" }));
+
+      expect(screen.getByTestId("touched")).toHaveTextContent("true");
+    });
   });
 
-  it("prompts when there is no value yet", () => {
-    render(<Harness initialValue="" />);
+  describe("24-hour mode", () => {
+    it("shows the 24h value on the trigger", () => {
+      render(<Harness initialValue="14:30" clockFormat="24h" />);
 
-    expect(
-      screen.getByRole("button", { name: "Pick a time" })
-    ).toBeInTheDocument();
-  });
+      expect(
+        screen.getByRole("button", { name: "14:30" })
+      ).toBeInTheDocument();
+    });
 
-  it("marks the current parts as pressed when opened", async () => {
-    await openPicker();
+    it("renders 00-23 hours and hides the AM/PM column", async () => {
+      await openPicker("14:30", "24h");
 
-    expect(column("Hour").getByRole("button", { name: "09" })).toHaveAttribute(
-      "aria-pressed",
-      "true"
-    );
-    expect(column("Minute").getByRole("button", { name: "05" })).toHaveAttribute(
-      "aria-pressed",
-      "true"
-    );
-    expect(column("AM/PM").getByRole("button", { name: "AM" })).toHaveAttribute(
-      "aria-pressed",
-      "true"
-    );
-  });
+      expect(column("Hour").getByRole("button", { name: "00" })).toBeInTheDocument();
+      expect(column("Hour").getByRole("button", { name: "14" })).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+      expect(column("Hour").getByRole("button", { name: "23" })).toBeInTheDocument();
+      expect(column("Minute").getByRole("button", { name: "30" })).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+      expect(screen.queryByRole("group", { name: "AM/PM" })).not.toBeInTheDocument();
+    });
 
-  it("keeps the minute and meridiem when the hour changes", async () => {
-    const { onChange } = await openPicker();
+    it("updates hour in 24h format", async () => {
+      const { onChange } = await openPicker("14:30", "24h");
 
-    await user.click(column("Hour").getByRole("button", { name: "11" }));
+      await user.click(column("Hour").getByRole("button", { name: "08" }));
 
-    expect(onChange).toHaveBeenCalledWith("11:05 AM");
-  });
+      expect(onChange).toHaveBeenCalledWith("08:30");
+    });
 
-  it("keeps the hour and meridiem when the minute changes", async () => {
-    const { onChange } = await openPicker();
+    it("updates minute in 24h format", async () => {
+      const { onChange } = await openPicker("14:30", "24h");
 
-    await user.click(column("Minute").getByRole("button", { name: "42" }));
+      await user.click(column("Minute").getByRole("button", { name: "45" }));
 
-    expect(onChange).toHaveBeenCalledWith("09:42 AM");
-  });
+      expect(onChange).toHaveBeenCalledWith("14:45");
+    });
 
-  it("keeps the hour and minute when the meridiem changes", async () => {
-    const { onChange } = await openPicker();
+    it("steps 24h time forward and backwards by 5 minutes", async () => {
+      const onChange = vi.fn();
+      render(<Harness initialValue="14:30" clockFormat="24h" onChange={onChange} />);
 
-    await user.click(column("AM/PM").getByRole("button", { name: "PM" }));
+      await user.click(screen.getByRole("button", { name: "5 minutes later" }));
+      expect(onChange).toHaveBeenLastCalledWith("14:35");
 
-    expect(onChange).toHaveBeenCalledWith("09:05 PM");
-  });
+      await user.click(screen.getByRole("button", { name: "5 minutes earlier" }));
+      expect(onChange).toHaveBeenLastCalledWith("14:30");
+    });
 
-  it("emits a padded value the schema regex accepts", async () => {
-    const { onChange } = await openPicker("");
+    it("wraps forward across midnight in 24h mode", async () => {
+      const onChange = vi.fn();
+      render(<Harness initialValue="23:58" clockFormat="24h" onChange={onChange} />);
 
-    await user.click(column("Hour").getByRole("button", { name: "03" }));
+      await user.click(screen.getByRole("button", { name: "5 minutes later" }));
 
-    // Unset parts fall back to 12:00 AM rather than emitting a partial string
-    expect(onChange).toHaveBeenCalledWith("03:00 AM");
-    expect(onChange.mock.calls[0][0]).toMatch(
-      /^(0[1-9]|1[0-2]):[0-5][0-9] (AM|PM)$/
-    );
-  });
+      expect(onChange).toHaveBeenLastCalledWith("00:03");
+    });
 
-  it("reflects the new value on the trigger", async () => {
-    await openPicker();
+    it("wraps backward across midnight in 24h mode", async () => {
+      const onChange = vi.fn();
+      render(<Harness initialValue="00:02" clockFormat="24h" onChange={onChange} />);
 
-    await user.click(column("AM/PM").getByRole("button", { name: "PM" }));
-    // The popover is modal, so the trigger stays aria-hidden until it closes
-    await user.keyboard("{Escape}");
+      await user.click(screen.getByRole("button", { name: "5 minutes earlier" }));
 
-    expect(
-      screen.getByRole("button", { name: "09:05 PM" })
-    ).toBeInTheDocument();
-  });
-
-  it("steps the time forward and back by five minutes", async () => {
-    const onChange = vi.fn();
-    render(<Harness onChange={onChange} />);
-
-    await user.click(screen.getByRole("button", { name: "5 minutes later" }));
-    expect(onChange).toHaveBeenLastCalledWith("09:10 AM");
-
-    await user.click(screen.getByRole("button", { name: "5 minutes earlier" }));
-    expect(onChange).toHaveBeenLastCalledWith("09:05 AM");
-  });
-
-  it("wraps the clock when a step crosses midnight", async () => {
-    const onChange = vi.fn();
-    render(<Harness initialValue="11:58 PM" onChange={onChange} />);
-
-    await user.click(screen.getByRole("button", { name: "5 minutes later" }));
-
-    expect(onChange).toHaveBeenLastCalledWith("12:03 AM");
-  });
-
-  it("wraps backwards across midnight too", async () => {
-    const onChange = vi.fn();
-    render(<Harness initialValue="12:02 AM" onChange={onChange} />);
-
-    await user.click(screen.getByRole("button", { name: "5 minutes earlier" }));
-
-    expect(onChange).toHaveBeenLastCalledWith("11:57 PM");
-  });
-
-  it("steps from midnight when there is no value yet", async () => {
-    const onChange = vi.fn();
-    render(<Harness initialValue="" onChange={onChange} />);
-
-    await user.click(screen.getByRole("button", { name: "5 minutes later" }));
-
-    expect(onChange).toHaveBeenLastCalledWith("12:05 AM");
-  });
-
-  // The onTouched validation mode never arms unless the trigger forwards blur
-  it("marks the field touched once the trigger loses focus", async () => {
-    render(<Harness />);
-    expect(screen.getByTestId("touched")).toHaveTextContent("false");
-
-    await user.click(screen.getByRole("button", { name: "09:05 AM" }));
-
-    expect(screen.getByTestId("touched")).toHaveTextContent("true");
+      expect(onChange).toHaveBeenLastCalledWith("23:57");
+    });
   });
 });

--- a/__tests__/clockFormat.spec.ts
+++ b/__tests__/clockFormat.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { combineDateAndTime, formatTime, formatDateTime } from "@/lib/utils";
+import { AddActivityFormSchema } from "@/models/addActivityForm.schema";
+import { defaultUserSettings } from "@/models/userSettings.model";
+
+describe("Clock Format Utilities", () => {
+  describe("defaultUserSettings", () => {
+    it("defaults to 12h clock format", () => {
+      expect(defaultUserSettings.display.clockFormat).toBe("12h");
+    });
+  });
+
+  describe("combineDateAndTime", () => {
+    it("parses 12-hour AM/PM time strings correctly", () => {
+      const baseDate = new Date(2026, 8, 7); // Sept 7, 2026
+      const result = combineDateAndTime(baseDate, "09:30 AM");
+      expect(result.getFullYear()).toBe(2026);
+      expect(result.getMonth()).toBe(8);
+      expect(result.getDate()).toBe(7);
+      expect(result.getHours()).toBe(9);
+      expect(result.getMinutes()).toBe(30);
+
+      const resultPM = combineDateAndTime(baseDate, "02:45 PM");
+      expect(resultPM.getHours()).toBe(14);
+      expect(resultPM.getMinutes()).toBe(45);
+    });
+
+    it("parses 24-hour time strings correctly", () => {
+      const baseDate = new Date(2026, 8, 7);
+      const result = combineDateAndTime(baseDate, "14:30");
+      expect(result.getFullYear()).toBe(2026);
+      expect(result.getMonth()).toBe(8);
+      expect(result.getDate()).toBe(7);
+      expect(result.getHours()).toBe(14);
+      expect(result.getMinutes()).toBe(30);
+
+      const resultMidnight = combineDateAndTime(baseDate, "00:15");
+      expect(resultMidnight.getHours()).toBe(0);
+      expect(resultMidnight.getMinutes()).toBe(15);
+    });
+  });
+
+  describe("formatTime", () => {
+    it("formats dates in 12h format by default", () => {
+      const date = new Date(2026, 8, 7, 14, 30);
+      expect(formatTime(date, "12h")).toBe("02:30 PM");
+      expect(formatTime(date)).toBe("02:30 PM");
+    });
+
+    it("formats dates in 24h format when requested", () => {
+      const date = new Date(2026, 8, 7, 14, 30);
+      expect(formatTime(date, "24h")).toBe("14:30");
+
+      const morning = new Date(2026, 8, 7, 9, 5);
+      expect(formatTime(morning, "24h")).toBe("09:05");
+    });
+
+    it("handles null / invalid dates gracefully", () => {
+      expect(formatTime("invalid")).toBe("");
+    });
+  });
+
+  describe("formatDateTime", () => {
+    it("formats date and time in 12h format", () => {
+      const date = new Date(2026, 8, 7, 14, 30);
+      expect(formatDateTime(date, "12h")).toBe("Sep 7, 2026 2:30 PM");
+    });
+
+    it("formats date and time in 24h format", () => {
+      const date = new Date(2026, 8, 7, 14, 30);
+      expect(formatDateTime(date, "24h")).toBe("Sep 7, 2026 14:30");
+    });
+  });
+
+  describe("AddActivityFormSchema", () => {
+    const baseValid = {
+      activityName: "Job Research",
+      activityType: "job-search",
+      startDate: new Date("2026-09-01T00:00:00.000Z"),
+      startTime: "09:00 AM",
+      endDate: new Date("2026-09-01T00:00:00.000Z"),
+      endTime: "10:00 AM",
+    };
+
+    it("accepts valid 12-hour start and end times", () => {
+      const result = AddActivityFormSchema.safeParse(baseValid);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts valid 24-hour start and end times", () => {
+      const result = AddActivityFormSchema.safeParse({
+        ...baseValid,
+        startTime: "14:00",
+        endTime: "15:30",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects invalid time strings", () => {
+      const result = AddActivityFormSchema.safeParse({
+        ...baseValid,
+        startTime: "25:00",
+      });
+      expect(result.success).toBe(false);
+
+      const result2 = AddActivityFormSchema.safeParse({
+        ...baseValid,
+        startTime: "9:00",
+      });
+      expect(result2.success).toBe(false);
+    });
+
+    it("validates end time is after start time with 24h clock", () => {
+      const result = AddActivityFormSchema.safeParse({
+        ...baseValid,
+        startTime: "15:00",
+        endTime: "14:00",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path.includes("endTime"))).toBe(true);
+      }
+    });
+  });
+});

--- a/src/actions/userSettings.actions.ts
+++ b/src/actions/userSettings.actions.ts
@@ -36,6 +36,14 @@ export const getUserSettings = async (): Promise<any | undefined> => {
         settings: {
           ...defaultUserSettings,
           ...settings,
+          ai: {
+            ...defaultUserSettings.ai,
+            ...settings?.ai,
+          },
+          display: {
+            ...defaultUserSettings.display,
+            ...settings?.display,
+          },
         },
       },
     };

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -14,6 +14,9 @@ import { getCurrentUser } from "@/utils/user.utils";
 import StaleSessionSignOut from "@/components/StaleSessionSignOut";
 import { signOut } from "@/auth";
 
+import { getUserSettings } from "@/actions/userSettings.actions";
+import { UserSettingsProvider } from "@/context/UserSettingsContext";
+
 export default async function RootLayout({
   children,
 }: Readonly<{
@@ -27,6 +30,7 @@ export default async function RootLayout({
   // is merged against an empty transcript and then persisted.
   const conversation = await getChatConversation();
   const user = await getCurrentUser();
+  const userSettingsResult = await getUserSettings();
 
   const signOutAction = async () => {
     "use server";
@@ -41,10 +45,11 @@ export default async function RootLayout({
   }
 
   return (
-    <ActivityProvider>
-      <SidebarProvider initialExpanded={initialExpanded}>
-        <RightRailProvider>
-          <AgentChatProvider initialMessages={conversation.data ?? []}>
+    <UserSettingsProvider initialSettings={userSettingsResult?.data?.settings}>
+      <ActivityProvider>
+        <SidebarProvider initialExpanded={initialExpanded}>
+          <RightRailProvider>
+            <AgentChatProvider initialMessages={conversation.data ?? []}>
             <div className="flex min-h-screen w-full flex-col bg-muted/40">
               <Sidebar user={user} signOutAction={signOutAction} />
               <SidebarInset>
@@ -66,5 +71,6 @@ export default async function RootLayout({
         </RightRailProvider>
       </SidebarProvider>
     </ActivityProvider>
+    </UserSettingsProvider>
   );
 }

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -13,19 +13,23 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { FormControl } from "./ui/form";
+import { ClockFormat } from "@/models/userSettings.model";
+import { useClockFormat } from "@/context/UserSettingsContext";
 
-const HOURS = Array.from({ length: 12 }, (_, i) =>
+const HOURS_12 = Array.from({ length: 12 }, (_, i) =>
   String(i + 1).padStart(2, "0")
+);
+const HOURS_24 = Array.from({ length: 24 }, (_, i) =>
+  String(i).padStart(2, "0")
 );
 const MINUTES = Array.from({ length: 60 }, (_, i) =>
   String(i).padStart(2, "0")
 );
 const MERIDIEMS = ["AM", "PM"];
 
-const TIME_PATTERN = /^(0[1-9]|1[0-2]):([0-5][0-9]) (AM|PM)$/;
+const TIME_12_PATTERN = /^(0[1-9]|1[0-2]):([0-5][0-9]) (AM|PM)$/;
+const TIME_24_PATTERN = /^([01][0-9]|2[0-3]):([0-5][0-9])$/;
 
-const TIME_FORMAT = "hh:mm a";
-const FALLBACK_TIME = "12:00 AM";
 const STEP_MINUTES = 5;
 
 type TimeParts = {
@@ -34,11 +38,44 @@ type TimeParts = {
   meridiem: string | null;
 };
 
-function parseTime(value: unknown): TimeParts {
-  const match = typeof value === "string" ? value.match(TIME_PATTERN) : null;
-  return match
-    ? { hour: match[1], minute: match[2], meridiem: match[3] }
-    : { hour: null, minute: null, meridiem: null };
+function parseTime(value: unknown, is24h: boolean): TimeParts {
+  if (typeof value !== "string") {
+    return { hour: null, minute: null, meridiem: null };
+  }
+
+  const match12 = value.match(TIME_12_PATTERN);
+  if (match12) {
+    if (is24h) {
+      let h = parseInt(match12[1], 10);
+      const isPM = match12[3] === "PM";
+      if (isPM && h < 12) h += 12;
+      if (!isPM && h === 12) h = 0;
+      return {
+        hour: String(h).padStart(2, "0"),
+        minute: match12[2],
+        meridiem: null,
+      };
+    }
+    return { hour: match12[1], minute: match12[2], meridiem: match12[3] };
+  }
+
+  const match24 = value.match(TIME_24_PATTERN);
+  if (match24) {
+    if (is24h) {
+      return { hour: match24[1], minute: match24[2], meridiem: null };
+    }
+    let h = parseInt(match24[1], 10);
+    const meridiem = h >= 12 ? "PM" : "AM";
+    if (h > 12) h -= 12;
+    if (h === 0) h = 12;
+    return {
+      hour: String(h).padStart(2, "0"),
+      minute: match24[2],
+      meridiem,
+    };
+  }
+
+  return { hour: null, minute: null, meridiem: null };
 }
 
 interface TimeColumnProps {
@@ -92,28 +129,50 @@ function TimeColumn({ label, options, selected, onSelect }: TimeColumnProps) {
 
 interface TimePickerProps {
   field: ControllerRenderProps<any, any>;
+  clockFormat?: ClockFormat;
 }
 
-export function TimePicker({ field }: TimePickerProps) {
+export function TimePicker({ field, clockFormat }: TimePickerProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
-  const { hour, minute, meridiem } = parseTime(field.value);
+  const contextFormat = useClockFormat();
+  const activeFormat: ClockFormat = clockFormat || contextFormat || "12h";
+  const is24h = activeFormat === "24h";
+
+  const { hour, minute, meridiem } = parseTime(field.value, is24h);
 
   const update = (parts: Partial<TimeParts>) => {
-    const next = {
-      hour: parts.hour ?? hour ?? "12",
-      minute: parts.minute ?? minute ?? "00",
-      meridiem: parts.meridiem ?? meridiem ?? "AM",
-    };
-    field.onChange(`${next.hour}:${next.minute} ${next.meridiem}`);
+    if (is24h) {
+      const nextHour = parts.hour ?? hour ?? "00";
+      const nextMinute = parts.minute ?? minute ?? "00";
+      field.onChange(`${nextHour}:${nextMinute}`);
+    } else {
+      const next = {
+        hour: parts.hour ?? hour ?? "12",
+        minute: parts.minute ?? minute ?? "00",
+        meridiem: parts.meridiem ?? meridiem ?? "AM",
+      };
+      field.onChange(`${next.hour}:${next.minute} ${next.meridiem}`);
+    }
   };
 
   // Stepping past midnight wraps the clock only — the date fields own the day
   const shift = (minutes: number) => {
-    const current = TIME_PATTERN.test(field.value)
-      ? field.value
-      : FALLBACK_TIME;
-    const stepped = addMinutes(parse(current, TIME_FORMAT, new Date()), minutes);
-    field.onChange(format(stepped, TIME_FORMAT));
+    const timeFormat = is24h ? "HH:mm" : "hh:mm a";
+    const fallback = is24h ? "00:00" : "12:00 AM";
+    let baseDate: Date;
+    if (typeof field.value === "string" && field.value) {
+      let parsed = parse(field.value, "hh:mm a", new Date());
+      if (isNaN(parsed.getTime())) {
+        parsed = parse(field.value, "HH:mm", new Date());
+      }
+      baseDate = isNaN(parsed.getTime())
+        ? parse(fallback, timeFormat, new Date())
+        : parsed;
+    } else {
+      baseDate = parse(fallback, timeFormat, new Date());
+    }
+    const stepped = addMinutes(baseDate, minutes);
+    field.onChange(format(stepped, timeFormat));
   };
 
   return (
@@ -138,7 +197,7 @@ export function TimePicker({ field }: TimePickerProps) {
         <PopoverContent className="flex w-auto gap-2 p-2" align="start">
           <TimeColumn
             label="Hour"
-            options={HOURS}
+            options={is24h ? HOURS_24 : HOURS_12}
             selected={hour}
             onSelect={(value) => update({ hour: value })}
           />
@@ -148,12 +207,14 @@ export function TimePicker({ field }: TimePickerProps) {
             selected={minute}
             onSelect={(value) => update({ minute: value })}
           />
-          <TimeColumn
-            label="AM/PM"
-            options={MERIDIEMS}
-            selected={meridiem}
-            onSelect={(value) => update({ meridiem: value })}
-          />
+          {!is24h && (
+            <TimeColumn
+              label="AM/PM"
+              options={MERIDIEMS}
+              selected={meridiem}
+              onSelect={(value) => update({ meridiem: value })}
+            />
+          )}
         </PopoverContent>
       </Popover>
       <Button

--- a/src/components/activities/ActivitiesTable.tsx
+++ b/src/components/activities/ActivitiesTable.tsx
@@ -23,6 +23,8 @@ import { deleteActivityById } from "@/actions/activity.actions";
 import { toastSuccess, toastError } from "@/lib/toast";
 import { useMemo, useState } from "react";
 import { DeleteAlertDialog } from "../DeleteAlertDialog";
+import { useClockFormat } from "@/context/UserSettingsContext";
+import { formatTime } from "@/lib/utils";
 
 interface ActivitiesTableProps {
   activities: Activity[];
@@ -35,6 +37,7 @@ function ActivitiesTable({
   reloadActivities,
   onStartActivity,
 }: ActivitiesTableProps) {
+  const clockFormat = useClockFormat();
   const [alertOpen, setAlertOpen] = useState(false);
   const [activityIdToDelete, setActivityIdToDelete] = useState<string>();
   const calculateDuration = (totalMinutes: number) => {
@@ -103,10 +106,14 @@ function ActivitiesTable({
                   {(activity.activityType as ActivityType)?.label}
                 </TableCell>
                 <TableCell className="hidden md:table-cell whitespace-nowrap">
-                  {format(activity.startTime, "p")}
+                  {activity.startTime
+                    ? formatTime(activity.startTime, clockFormat)
+                    : "N/A"}
                 </TableCell>
                 <TableCell className="hidden md:table-cell whitespace-nowrap">
-                  {format(activity.endTime!, "p")}
+                  {activity.endTime
+                    ? formatTime(activity.endTime, clockFormat)
+                    : "N/A"}
                 </TableCell>
                 <TableCell>
                   {activity.startTime &&

--- a/src/components/activities/ActivityForm.tsx
+++ b/src/components/activities/ActivityForm.tsx
@@ -34,6 +34,8 @@ import {
 import { combineDateAndTime } from "@/lib/utils";
 import { toastActionResult, toastError } from "@/lib/toast";
 
+import { useClockFormat } from "@/context/UserSettingsContext";
+
 interface ActivityFormProps {
   onClose: () => void;
   reloadActivities: () => void;
@@ -48,13 +50,15 @@ const ActivityFormComponent = ({
   onClose,
   reloadActivities,
 }: ActivityFormProps) => {
+  const clockFormat = useClockFormat();
   const [activityTypes, setActivityTypes] = useState<ActivityType[]>([]);
   const [duration, setDuration] = useState<Duration | null>(null);
   const defaultValues = useMemo(() => {
     const now = new Date();
-    const currentTime = format(now, "hh:mm a");
+    const timePattern = clockFormat === "24h" ? "HH:mm" : "hh:mm a";
+    const currentTime = format(now, timePattern);
     const nowPlus5mins = addMinutes(now, 5);
-    const estimatedEndTime = format(nowPlus5mins, "hh:mm a");
+    const estimatedEndTime = format(nowPlus5mins, timePattern);
 
     return {
       activityName: "",
@@ -64,7 +68,7 @@ const ActivityFormComponent = ({
       endDate: now,
       endTime: estimatedEndTime,
     };
-  }, []);
+  }, [clockFormat]);
   const form = useForm<z.infer<typeof AddActivityFormSchema>>({
     resolver: zodResolver(AddActivityFormSchema),
     defaultValues,
@@ -224,7 +228,7 @@ const ActivityFormComponent = ({
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Start Time</FormLabel>
-                <TimePicker field={field} />
+                <TimePicker field={field} clockFormat={clockFormat} />
                 <FormMessage>
                   {errors.startTime && (
                     <span className="text-red-500">
@@ -276,7 +280,7 @@ const ActivityFormComponent = ({
                     )}
                   </span>
                 </FormLabel>
-                <TimePicker field={field} />
+                <TimePicker field={field} clockFormat={clockFormat} />
                 <FormMessage>
                   {errors.endTime && (
                     <span className="text-red-500">

--- a/src/components/pdf-export/PdfPreviewPane.tsx
+++ b/src/components/pdf-export/PdfPreviewPane.tsx
@@ -133,7 +133,7 @@ export function PdfPreviewPane({
 
     let cancelled = false;
     let renderTask: { cancel: () => void } | null = null;
-    let document_: { destroy: () => Promise<void> } | null = null;
+    let document_: { destroy?: () => Promise<void> } | null = null;
 
     // A stale failure must not suppress this attempt's spinner.
     setRenderFailed(false);
@@ -147,7 +147,7 @@ export function PdfPreviewPane({
 
         const pdf = await getDocumentProxy(bytes);
         if (cancelled) {
-          void pdf.destroy().catch(() => {});
+          void (pdf as { destroy?: () => Promise<void> }).destroy?.()?.catch(() => {});
           return;
         }
         document_ = pdf;
@@ -210,7 +210,7 @@ export function PdfPreviewPane({
       renderTask?.cancel();
       // destroy() rejects any page work still in flight; that is the point of
       // the call, so the rejection is swallowed rather than left floating.
-      void document_?.destroy().catch(() => {});
+      void document_?.destroy?.()?.catch(() => {});
     };
   }, [blob, size, fitMode]);
 

--- a/src/components/settings/DisplaySettings.tsx
+++ b/src/components/settings/DisplaySettings.tsx
@@ -22,9 +22,15 @@ import {
   updateDisplaySettings,
 } from "@/actions/userSettings.actions";
 
+import { useUserSettings } from "@/context/UserSettingsContext";
+import { Clock } from "lucide-react";
+
 const appearanceFormSchema = z.object({
   theme: z.enum(["light", "dark", "system"], {
     error: "Please select a theme.",
+  }),
+  clockFormat: z.enum(["12h", "24h"], {
+    error: "Please select a clock format.",
   }),
 });
 
@@ -32,6 +38,7 @@ type AppearanceFormValues = z.infer<typeof appearanceFormSchema>;
 
 function DisplaySettings() {
   const { setTheme, theme, systemTheme } = useTheme();
+  const { updateDisplay } = useUserSettings();
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -39,6 +46,7 @@ function DisplaySettings() {
     resolver: zodResolver(appearanceFormSchema),
     defaultValues: {
       theme: "system",
+      clockFormat: "12h",
     },
   });
 
@@ -47,17 +55,25 @@ function DisplaySettings() {
       setIsLoading(true);
       try {
         const result = await getUserSettings();
-        if (result.success && result.data?.settings?.display?.theme) {
-          const savedTheme = result.data.settings.display.theme;
-          form.reset({ theme: savedTheme });
+        const display = result.data?.settings?.display;
+        if (result.success && display) {
+          const savedTheme = display.theme || "system";
+          const savedClock = display.clockFormat || "12h";
+          form.reset({ theme: savedTheme, clockFormat: savedClock });
           setTheme(savedTheme);
         } else if (theme) {
-          form.reset({ theme: theme as "light" | "dark" | "system" });
+          form.reset({
+            theme: theme as "light" | "dark" | "system",
+            clockFormat: "12h",
+          });
         }
       } catch (error) {
         console.error("Error fetching display settings:", error);
         if (theme) {
-          form.reset({ theme: theme as "light" | "dark" | "system" });
+          form.reset({
+            theme: theme as "light" | "dark" | "system",
+            clockFormat: "12h",
+          });
         }
       } finally {
         setIsLoading(false);
@@ -70,10 +86,17 @@ function DisplaySettings() {
   async function onSubmit(data: AppearanceFormValues) {
     setIsSaving(true);
     try {
-      const result = await updateDisplaySettings({ theme: data.theme });
+      const result = await updateDisplaySettings({
+        theme: data.theme,
+        clockFormat: data.clockFormat,
+      });
       if (result.success) {
         setTheme(data.theme);
-        toastSuccess("Your selected theme has been saved.");
+        updateDisplay({
+          theme: data.theme,
+          clockFormat: data.clockFormat,
+        });
+        toastSuccess("Display settings have been saved.");
       } else {
         toastError(result.message || "Failed to save display settings.");
       }
@@ -89,9 +112,9 @@ function DisplaySettings() {
     return (
       <div className="space-y-4">
         <div>
-          <h3 className="text-lg font-medium">Appearance</h3>
+          <h3 className="text-lg font-medium">Appearance & Display</h3>
           <p className="text-sm text-muted-foreground">
-            Customize the look and feel of the application.
+            Customize the look and feel and time preferences of the application.
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -105,9 +128,9 @@ function DisplaySettings() {
   return (
     <div className="space-y-4">
       <div>
-        <h3 className="text-lg font-medium">Appearance</h3>
+        <h3 className="text-lg font-medium">Appearance & Display</h3>
         <p className="text-sm text-muted-foreground">
-          Customize the look and feel of the application.
+          Customize the look and feel and time preferences of the application.
         </p>
       </div>
       <div className="@container">
@@ -163,6 +186,58 @@ function DisplaySettings() {
                         <span className="block w-full p-2 text-center font-normal">
                           System
                         </span>
+                      </FormLabel>
+                    </FormItem>
+                  </RadioGroup>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="clockFormat"
+              render={({ field }) => (
+                <FormItem className="space-y-1">
+                  <FormLabel>Clock Format</FormLabel>
+                  <FormDescription>
+                    Choose between 12-hour (AM/PM) and 24-hour time format.
+                  </FormDescription>
+                  <FormMessage />
+                  <RadioGroup
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    className="grid max-w-lg @md:grid-cols-2 gap-4 pt-2"
+                  >
+                    <FormItem>
+                      <FormLabel className="[&:has([data-state=checked])>div]:border-primary block cursor-pointer">
+                        <FormControl>
+                          <RadioGroupItem value="12h" className="sr-only" />
+                        </FormControl>
+                        <div className="flex items-center gap-3 rounded-md border-2 border-muted p-4 hover:border-accent">
+                          <Clock className="h-5 w-5 text-muted-foreground shrink-0" />
+                          <div>
+                            <span className="block font-medium">12-hour</span>
+                            <span className="block text-xs text-muted-foreground">
+                              e.g. 02:30 PM
+                            </span>
+                          </div>
+                        </div>
+                      </FormLabel>
+                    </FormItem>
+                    <FormItem>
+                      <FormLabel className="[&:has([data-state=checked])>div]:border-primary block cursor-pointer">
+                        <FormControl>
+                          <RadioGroupItem value="24h" className="sr-only" />
+                        </FormControl>
+                        <div className="flex items-center gap-3 rounded-md border-2 border-muted p-4 hover:border-accent">
+                          <Clock className="h-5 w-5 text-muted-foreground shrink-0" />
+                          <div>
+                            <span className="block font-medium">24-hour</span>
+                            <span className="block text-xs text-muted-foreground">
+                              e.g. 14:30
+                            </span>
+                          </div>
+                        </div>
                       </FormLabel>
                     </FormItem>
                   </RadioGroup>

--- a/src/components/tasks/TaskForm.tsx
+++ b/src/components/tasks/TaskForm.tsx
@@ -34,6 +34,8 @@ import { Input } from "../ui/input";
 import { Combobox } from "../ComboBox";
 import { Slider } from "../ui/slider";
 import { ActivityType } from "@/models/activity.model";
+import { useClockFormat } from "@/context/UserSettingsContext";
+import { formatDateTime } from "@/lib/utils";
 
 type TaskFormProps = {
   activityTypes: ActivityType[];
@@ -60,6 +62,7 @@ export function TaskForm({
   setDialogOpen,
   onSaveAndStart,
 }: TaskFormProps) {
+  const clockFormat = useClockFormat();
   const [isPending, startTransition] = useTransition();
   const form = useForm<z.infer<typeof AddTaskFormSchema>>({
     resolver: zodResolver(AddTaskFormSchema),
@@ -299,10 +302,7 @@ export function TaskForm({
                     <p className="text-sm font-medium">Created</p>
                     <p className="text-sm text-muted-foreground">
                       {editTask.createdAt
-                        ? format(
-                            new Date(editTask.createdAt),
-                            "MMM d, yyyy h:mm a",
-                          )
+                        ? formatDateTime(editTask.createdAt, clockFormat)
                         : "N/A"}
                     </p>
                   </div>
@@ -310,10 +310,7 @@ export function TaskForm({
                     <p className="text-sm font-medium">Updated</p>
                     <p className="text-sm text-muted-foreground">
                       {editTask.updatedAt
-                        ? format(
-                            new Date(editTask.updatedAt),
-                            "MMM d, yyyy h:mm a",
-                          )
+                        ? formatDateTime(editTask.updatedAt, clockFormat)
                         : "N/A"}
                     </p>
                   </div>

--- a/src/context/UserSettingsContext.tsx
+++ b/src/context/UserSettingsContext.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  ClockFormat,
+  defaultUserSettings,
+  DisplaySettings,
+  UserSettingsData,
+} from "@/models/userSettings.model";
+import {
+  getUserSettings,
+  updateDisplaySettings,
+} from "@/actions/userSettings.actions";
+import { formatDateTime, formatTime } from "@/lib/utils";
+
+interface UserSettingsContextType {
+  settings: UserSettingsData;
+  clockFormat: ClockFormat;
+  setClockFormat: (clockFormat: ClockFormat) => Promise<boolean>;
+  updateDisplay: (display: Partial<DisplaySettings>) => Promise<boolean>;
+  refreshSettings: () => Promise<void>;
+  formatTime: (date: Date | string | number) => string;
+  formatDateTime: (date: Date | string | number) => string;
+}
+
+const UserSettingsContext = createContext<UserSettingsContextType | undefined>(
+  undefined
+);
+
+interface UserSettingsProviderProps {
+  children: React.ReactNode;
+  initialSettings?: UserSettingsData;
+}
+
+export function UserSettingsProvider({
+  children,
+  initialSettings,
+}: UserSettingsProviderProps) {
+  const [settings, setSettings] = useState<UserSettingsData>(() => ({
+    ...defaultUserSettings,
+    ...initialSettings,
+    display: {
+      ...defaultUserSettings.display,
+      ...initialSettings?.display,
+    },
+    ai: {
+      ...defaultUserSettings.ai,
+      ...initialSettings?.ai,
+    },
+  }));
+
+  const refreshSettings = useCallback(async () => {
+    try {
+      const res = await getUserSettings();
+      if (res?.success && res.data?.settings) {
+        setSettings({
+          ...defaultUserSettings,
+          ...res.data.settings,
+          display: {
+            ...defaultUserSettings.display,
+            ...res.data.settings.display,
+          },
+          ai: {
+            ...defaultUserSettings.ai,
+            ...res.data.settings.ai,
+          },
+        });
+      }
+    } catch (err) {
+      console.error("Failed to load user settings:", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!initialSettings) {
+      refreshSettings();
+    }
+  }, [initialSettings, refreshSettings]);
+
+  const clockFormat: ClockFormat = settings.display?.clockFormat || "12h";
+
+  const updateDisplay = useCallback(
+    async (display: Partial<DisplaySettings>): Promise<boolean> => {
+      const mergedDisplay = {
+        ...settings.display,
+        ...display,
+      };
+      setSettings((prev) => ({
+        ...prev,
+        display: mergedDisplay,
+      }));
+
+      try {
+        const res = await updateDisplaySettings(mergedDisplay);
+        if (!res?.success) {
+          await refreshSettings();
+          return false;
+        }
+        return true;
+      } catch (err) {
+        console.error("Failed to update display settings:", err);
+        await refreshSettings();
+        return false;
+      }
+    },
+    [settings.display, refreshSettings]
+  );
+
+  const setClockFormat = useCallback(
+    async (newFormat: ClockFormat): Promise<boolean> => {
+      return updateDisplay({ clockFormat: newFormat });
+    },
+    [updateDisplay]
+  );
+
+  const formatTimeHelper = useCallback(
+    (date: Date | string | number) => {
+      return formatTime(date, clockFormat);
+    },
+    [clockFormat]
+  );
+
+  const formatDateTimeHelper = useCallback(
+    (date: Date | string | number) => {
+      return formatDateTime(date, clockFormat);
+    },
+    [clockFormat]
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      settings,
+      clockFormat,
+      setClockFormat,
+      updateDisplay,
+      refreshSettings,
+      formatTime: formatTimeHelper,
+      formatDateTime: formatDateTimeHelper,
+    }),
+    [
+      settings,
+      clockFormat,
+      setClockFormat,
+      updateDisplay,
+      refreshSettings,
+      formatTimeHelper,
+      formatDateTimeHelper,
+    ]
+  );
+
+  return (
+    <UserSettingsContext.Provider value={contextValue}>
+      {children}
+    </UserSettingsContext.Provider>
+  );
+}
+
+export function useUserSettings(): UserSettingsContextType {
+  const context = useContext(UserSettingsContext);
+  if (!context) {
+    // Fallback for tests or out-of-provider components
+    return {
+      settings: defaultUserSettings,
+      clockFormat: "12h",
+      setClockFormat: async () => false,
+      updateDisplay: async () => false,
+      refreshSettings: async () => {},
+      formatTime: (date) => formatTime(date, "12h"),
+      formatDateTime: (date) => formatDateTime(date, "12h"),
+    };
+  }
+  return context;
+}
+
+export function useClockFormat(): ClockFormat {
+  const { clockFormat } = useUserSettings();
+  return clockFormat;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,6 +2,7 @@ import { type ClassValue, clsx } from "clsx";
 import { format, parse } from "date-fns";
 import { NextApiRequest } from "next";
 import { twMerge } from "tailwind-merge";
+import { ClockFormat } from "@/models/userSettings.model";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -81,8 +82,13 @@ export function getTimestampedFileName(originalName: string): string {
 
 export const combineDateAndTime = (date: Date, time: string): Date => {
   // Parse the time string into a `Date` object using a reference date
-  const parsedTime = parse(time, "hh:mm a", new Date());
-  // if (isNaN(parsedTime.getTime())) throw new Error("Invalid time format");
+  let parsedTime = parse(time, "hh:mm a", new Date());
+  if (isNaN(parsedTime.getTime())) {
+    parsedTime = parse(time, "HH:mm", new Date());
+  }
+  if (isNaN(parsedTime.getTime())) {
+    parsedTime = parse(time, "h:mm a", new Date());
+  }
 
   return new Date(
     date.getFullYear(),
@@ -90,6 +96,29 @@ export const combineDateAndTime = (date: Date, time: string): Date => {
     date.getDate(),
     parsedTime.getHours(),
     parsedTime.getMinutes()
+  );
+};
+
+export const formatTime = (
+  date: Date | string | number,
+  clockFormat: ClockFormat = "12h"
+): string => {
+  const d =
+    typeof date === "string" || typeof date === "number" ? new Date(date) : date;
+  if (!d || isNaN(d.getTime())) return "";
+  return format(d, clockFormat === "24h" ? "HH:mm" : "hh:mm a");
+};
+
+export const formatDateTime = (
+  date: Date | string | number,
+  clockFormat: ClockFormat = "12h"
+): string => {
+  const d =
+    typeof date === "string" || typeof date === "number" ? new Date(date) : date;
+  if (!d || isNaN(d.getTime())) return "";
+  return format(
+    d,
+    clockFormat === "24h" ? "MMM d, yyyy HH:mm" : "MMM d, yyyy h:mm a"
   );
 };
 

--- a/src/models/addActivityForm.schema.ts
+++ b/src/models/addActivityForm.schema.ts
@@ -21,15 +21,15 @@ export const AddActivityFormSchema = z
     startTime: z
       .string()
       .regex(
-        /^(0[1-9]|1[0-2]):[0-5][0-9] (AM|PM)$/,
-        "Start time must be in hh:mm AM/PM format"
+        /^(?:(0[1-9]|1[0-2]):[0-5][0-9] (AM|PM)|([01][0-9]|2[0-3]):[0-5][0-9])$/,
+        "Start time must be in valid 12-hour (hh:mm AM/PM) or 24-hour (HH:mm) format"
       ),
     endDate: z.date().optional(),
     endTime: z
       .string()
       .regex(
-        /^(0[1-9]|1[0-2]):[0-5][0-9] (AM|PM)$/,
-        "End time must be in hh:mm AM/PM format"
+        /^(?:(0[1-9]|1[0-2]):[0-5][0-9] (AM|PM)|([01][0-9]|2[0-3]):[0-5][0-9])$/,
+        "End time must be in valid 12-hour (hh:mm AM/PM) or 24-hour (HH:mm) format"
       )
       .optional(),
     duration: z

--- a/src/models/userSettings.model.ts
+++ b/src/models/userSettings.model.ts
@@ -5,8 +5,11 @@ export interface AiSettings {
   model: string | undefined;
 }
 
+export type ClockFormat = "12h" | "24h";
+
 export interface DisplaySettings {
   theme: "light" | "dark" | "system";
+  clockFormat?: ClockFormat;
 }
 
 export interface UserSettingsData {
@@ -26,5 +29,7 @@ export const defaultUserSettings: UserSettingsData = {
   },
   display: {
     theme: "system",
+    clockFormat: "12h",
   },
 };
+


### PR DESCRIPTION
### Description
Closes #112

This PR adds an option in the Display Settings to toggle between a 12-hour (AM/PM) and 24-hour clock format. The selected setting is reflected across the entire application:

- **Display Settings**: Added a Clock Format section (12-hour vs 24-hour options).
- **TimePicker**: Supports 24-hour mode (00–23 hours, 00–59 minutes, hiding the AM/PM column) with 5-minute step shifting.
- **Activity Form & Table**: Form initializes with default times matching the chosen format, and activity start/end times in the table render using the selected clock.
- **Validation**: Updated `AddActivityFormSchema` and `combineDateAndTime` helper to parse and validate both 12h and 24h time strings.
- **Context**: Added `UserSettingsContext` for reactive dashboard-wide updates upon saving settings.

### Testing
- Added unit tests for 12h and 24h mode in `__tests__/TimePicker.spec.tsx` and `__tests__/clockFormat.spec.ts`.
- Ran full test suite (2575 tests passing).
- Verified production build completes successfully (`npm run build`).
